### PR TITLE
Add /grep, backed by regex-tdfa

### DIFF
--- a/irc-core.cabal
+++ b/irc-core.cabal
@@ -98,7 +98,8 @@ library
                        free             >= 4.11     && < 4.13,
                        lens             >= 4.7      && < 4.13,
                        text             >= 1.2.0.4  && < 1.3,
-                       transformers     >= 0.2      && < 0.5
+                       transformers     >= 0.2      && < 0.5,
+                       regex-tdfa       >= 1.2      && < 1.3
 
   if flag(time15)
     build-depends:     time             >= 1.5      && < 1.6
@@ -153,7 +154,8 @@ executable glirc
                  time             >= 1.4.2    && < 1.6,
                  vty              >= 5.2.7    && < 5.5,
                  haskell-lexer    >= 1.0      && < 1.1,
-                 transformers     >= 0.2      && < 0.5
+                 transformers     >= 0.2      && < 0.5,
+                 regex-tdfa       >= 1.2      && < 1.3
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
The regex feature.  It (hackishly) constructs each message as a string `"username: message that might not even be a IRC message but some other type of text from some other command"` then applies the regular expression.

This could be viewed as two patches - one that abstracts out filtering so we can add more types of filtering in the future (`/monads`, `/friends`, `/conversation-starting-lines-based-on-kmeans-clustering` etc) and another that adds the regex.

I avoided the `tdfa-text` package as it still does not build with 7.10 - hence the conversion to string prior to applying regex.