### PR TITLE
Include Year-Month-Day in the detailed view

### DIFF
--- a/driver/Views/Channel.hs
+++ b/driver/Views/Channel.hs
@@ -96,7 +96,7 @@ detailedImageForState !st
 renderTimestamp :: TimeZone -> UTCTime -> Image
 renderTimestamp zone
   = string (withForeColor defAttr brightBlack)
-  . formatTime defaultTimeLocale "%H:%M:%S "
+  . formatTime defaultTimeLocale "%F %H:%M:%S "
   . utcToZonedTime zone
 
 renderCompressedTimestamp :: TimeZone -> UTCTime -> Image


### PR DESCRIPTION
I run glirc for weeks at a time these days.  Not being able to tell if a conversation was this morning or last week is unproductive.