### PR TITLE
Working DCC SEND handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Filters
 * `/filter` - Filter chat messages by space-delimited set of nicknames
 * `/grep` - Filter chat messages using a regular expression on the message
 
+DCC commands
+
+* `/transfers` - Show the DCC Offers and the ongoing progress
+* `/dcc accept` - On the sender window starts the download
+* `/dcc cancel` - as above but drops the offer and informs the sender with xdcc cancel
+
 Keyboard Shortcuts
 ==================
 

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -103,7 +103,7 @@ data Focus
   = ChannelFocus Identifier
   | ChannelInfoFocus Identifier
   | MaskListFocus Char Identifier
-  | DCCFocus
+  | DCCFocus Identifier
   deriving (Eq, Ord, Read, Show)
 
 data EventHandler = EventHandler
@@ -197,6 +197,7 @@ incrementFocus f st
     case view clientFocus st of
       ChannelInfoFocus c -> ChannelFocus c
       MaskListFocus _  c -> ChannelFocus c
+      DCCFocus c         -> ChannelFocus c
       ChannelFocus c     -> ChannelFocus (f c focuses)
 
   focuses = Map.keysSet (fullMessageLists st)
@@ -216,12 +217,14 @@ focusedName st =
     ChannelInfoFocus c -> c
     MaskListFocus _  c -> c
     ChannelFocus     c -> c
+    DCCFocus _         -> "DCCWindow"
 
 focusedChan :: ClientState -> Maybe Identifier
 focusedChan st =
   case view clientFocus st of
     ChannelInfoFocus c -> Just c
     MaskListFocus _  c -> Just c
+    DCCFocus         _ -> Nothing
     ChannelFocus     c
       | isChannelName c (view (clientServer0.ccConnection) st) -> Just c
       | otherwise -> Nothing

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -38,7 +38,7 @@ import Irc.Format
 import Irc.Message
 import Irc.Model
 
-import DCC (DCCOffer)
+import DCC
 import Connection
 import EditBox (EditBox)
 import qualified EditBox as Edit
@@ -72,7 +72,7 @@ data ClientState = ClientState
   , _clientIgnores :: !(Set Identifier) -- Todo: support mask matching
   , _clientHighlights :: !(Set ByteString)
   , _clientMessages :: !(Map Identifier MessageList)
-  , _clientDcc        :: TChan DCCOffer
+  , _clientDcc        :: TChan [ByteString]
   , _clientNickColors :: [Color]
   , _clientAutomation :: [EventHandler]
   , _clientTimers     :: Map UTCTime [TimerEvent]

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -51,6 +51,7 @@ data ClientConnection = ClientConnection
   , _ccSendChan       :: Maybe (IORef Bool, TChan ByteString)
   , _ccRecvThread     :: Maybe ThreadId
   , _ccSendThread     :: Maybe ThreadId
+  , _ccHoldDccTrans   :: Map Identifier DCCOffer
   }
 
 data ClientState = ClientState
@@ -72,7 +73,6 @@ data ClientState = ClientState
   , _clientIgnores :: !(Set Identifier) -- Todo: support mask matching
   , _clientHighlights :: !(Set ByteString)
   , _clientMessages :: !(Map Identifier MessageList)
-  , _clientDcc        :: TChan [ByteString]
   , _clientNickColors :: [Color]
   , _clientAutomation :: [EventHandler]
   , _clientTimers     :: Map UTCTime [TimerEvent]

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -38,6 +38,7 @@ import Irc.Format
 import Irc.Message
 import Irc.Model
 
+import DCC (DCCOffer)
 import Connection
 import EditBox (EditBox)
 import qualified EditBox as Edit
@@ -71,6 +72,7 @@ data ClientState = ClientState
   , _clientIgnores :: !(Set Identifier) -- Todo: support mask matching
   , _clientHighlights :: !(Set ByteString)
   , _clientMessages :: !(Map Identifier MessageList)
+  , _clientDcc        :: TChan DCCOffer
   , _clientNickColors :: [Color]
   , _clientAutomation :: [EventHandler]
   , _clientTimers     :: Map UTCTime [TimerEvent]

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -104,7 +104,7 @@ data Focus
   = ChannelFocus Identifier
   | ChannelInfoFocus Identifier
   | MaskListFocus Char Identifier
-  | DCCFocus Identifier
+  | DCCFocus Focus
   deriving (Eq, Ord, Read, Show)
 
 data EventHandler = EventHandler
@@ -198,7 +198,7 @@ incrementFocus f st
     case view clientFocus st of
       ChannelInfoFocus c -> ChannelFocus c
       MaskListFocus _  c -> ChannelFocus c
-      DCCFocus c         -> ChannelFocus c
+      DCCFocus oldFocus  -> oldFocus
       ChannelFocus c     -> ChannelFocus (f c focuses)
 
   focuses = Map.keysSet (fullMessageLists st)

--- a/driver/ClientState.hs
+++ b/driver/ClientState.hs
@@ -75,6 +75,7 @@ data ClientState = ClientState
   , _clientMessages :: !(Map Identifier MessageList)
   , _clientNickColors :: [Color]
   , _clientAutomation :: [EventHandler]
+  , _clientDCCTransfers :: [Transfer]
   , _clientTimers     :: Map UTCTime [TimerEvent]
   , _clientTimeZone   :: TimeZone
   }
@@ -102,6 +103,7 @@ data Focus
   = ChannelFocus Identifier
   | ChannelInfoFocus Identifier
   | MaskListFocus Char Identifier
+  | DCCFocus
   deriving (Eq, Ord, Read, Show)
 
 data EventHandler = EventHandler

--- a/driver/CtcpHandler.hs
+++ b/driver/CtcpHandler.hs
@@ -4,25 +4,18 @@ module CtcpHandler where
 
 import Control.Lens
 import Control.Monad
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.State.Strict
 import Control.Applicative
 import Control.Concurrent
-import Control.Concurrent.STM
-import Control.Concurrent.STM.TChan
 import Data.ByteString (ByteString)
 import Data.Monoid
 import Data.Map as Map
-import Data.Set as Set
 import Data.Maybe
-import Data.Functor (void)
-import Data.Time (formatTime, getZonedTime)
+import Data.Time
 import Data.Version (showVersion)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Config.Lens as C
 
 #if MIN_VERSION_time(1,5,0)
 import Data.Time (defaultTimeLocale)
@@ -31,7 +24,6 @@ import System.Locale (defaultTimeLocale)
 #endif
 
 import ClientState
-import CommandArgs
 import DCC
 import ServerSettings
 import Irc.Format
@@ -82,28 +74,18 @@ ctcpHandler = EventHandler
           return (over clientAutomation (cons ctcpHandler) st)
   }
 
-{-
-scheme of work: We receive a ctcp message of DCC SEND, with dccHandler we
-set up such offer on the data structure
+-- ideally this would be in DCC but hs-boot files are a pain
+-- time limit between offer and acceptance of connection 90s.
+pruneStaleOffers :: ClientState -> IO ClientState
+pruneStaleOffers st =
+  do now <- getCurrentTime
+     let cond offer = diffUTCTime now (_doTime offer) < 90
+     return $ over (clientServer0 . ccHoldDccTrans) (Map.filter cond) st
 
-    (Map Identifier (DCCOffer, Maybe Progress))
-
-were it waits until the user goes to the identifier windows
-and issues a /dcc accept to start processing. On this command a new
-thread is launched that downloads the file. To this thread is passed a MVar
-(type Progress) which logs how much data have we gotten. Because reading
-the MVar is a IO action, we set up a read on `ClientState` on
-clientDCCTransfer such that `dccImage` will create a picture based on it.
-The thing is where to set up such values, current alternative seems to do
-another handler.
--}
-progressHandler :: EventHandler
-progressHandler = EventHandler
-  { _evName = "dcc progress handler"
-  , _evOnEvent = \_ _ st ->
-      over (mapped . clientAutomation) (cons progressHandler)
-      . traverseOf (clientDCCTransfers . traverse) (update . prune) $ st
-  }
+-- traverseOf means more clarity(?)
+checkTransfers :: ClientState -> IO ClientState
+checkTransfers = traverseOf (clientDCCTransfers . traverse)
+                               (update . graduate)
   where
     update :: Transfer -> IO Transfer
     update trans
@@ -114,8 +96,8 @@ progressHandler = EventHandler
               Nothing       -> return $ trans
       | otherwise = return trans
 
-    prune :: Transfer -> Transfer
-    prune trans
+    graduate :: Transfer -> Transfer
+    graduate trans
       | (Ongoing name size curSize _ _) <- trans,
         size == curSize = Finished name size
       | otherwise       = trans
@@ -128,21 +110,23 @@ dccHandler outDir = EventHandler
                        (queueOffer outDir ident msg st)
   }
 
+-- todo(slack): better message to the user (this is a hack)
 -- | We assume ctcpHandler already ran and created the corresponding window.
-userConfirm :: IrcMessage -> ClientState -> ClientState
-userConfirm msg st =
-  let sender = views mesgSender userNick msg
-      questionText = PrivMsgType $ "You have a pending DCC transfer. /dcc"
+userConfirm :: Identifier -> ClientState -> ClientState
+userConfirm sender st =
+  let questionText = PrivMsgType $ "You have a pending DCC transfer. /dcc"
                        <> " accept it or /dcc cancel"
   in addMessage sender (set mesgType questionText defaultIrcMessage) st
 
-queueOffer :: FilePath -> Identifier -> IrcMessage -> ClientState -> ClientState
+queueOffer :: FilePath -> Identifier -> IrcMessage
+           -> ClientState -> ClientState
 queueOffer outDir _ msg st = fromJust $
     (notIgnored >> isCtcpMsg >>= isDCCcommand
-     >>= pure . userConfirm msg . storeOffer) <|> Just st
+     >>= pure . userConfirm sender . storeOffer) <|> Just st
   where
     space = 0x20
     sender = views mesgSender userNick msg
+    ctime  = view mesgStamp msg
 
     -- Could be an 'if then else' but the shortcircuit of Maybe is
     -- clearer. () really could be any type.
@@ -153,17 +137,17 @@ queueOffer outDir _ msg st = fromJust $
     isCtcpMsg :: Maybe (ByteString, ByteString)
     isCtcpMsg = preview (mesgType . _CtcpReqMsgType) msg
 
-    isDCCcommand :: (ByteString, ByteString) -> Maybe [ByteString]
+    isDCCcommand :: (ByteString, ByteString) -> Maybe (FourTuple ByteString)
     isDCCcommand ("DCC", params)
-      | type' : offer <- take 5 (B.split space params)
-      , type' == "SEND" = Just offer
+      | [type',  bName, bAddr, bPort, bSize] <- take 5 (B.split space params)
+      , type' == "SEND" = Just (bName, bAddr, bPort, bSize)
     isDCCcommand _ = Nothing
 
     -- Store the offer until the user accepts it on /dcc accept
-    storeOffer :: [ByteString] -> ClientState
+    storeOffer :: FourTuple ByteString -> ClientState
     storeOffer offer =
       set (clientServer0 . ccHoldDccTrans . at sender)
-          (Just (parseDccOffer outDir offer)) st
+          (Just (parseDccOffer ctime outDir offer)) st
 
 retrieveAndStartOffer :: ClientState -> Maybe (IO ClientState)
 retrieveAndStartOffer st = do

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -1,0 +1,121 @@
+{-# language OverloadedStrings #-}
+module DCC where
+
+import           Prelude        hiding (getContents, log)
+import           Control.Applicative
+import           Control.Monad.Trans.Class
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.State as S
+import           Control.Monad.Trans.Except
+import           Control.Exception     (bracket)
+import           Control.Lens
+import           Data.Bits      hiding (complement)
+import           Data.Function         (fix)
+import           Data.Int              (Int64)
+import           Network.BSD
+import           Network.Socket hiding (send, sendTo, recv, recvFrom)
+import qualified Network.Socket            as SS
+import qualified System.IO                 as IO
+import qualified Network.Socket.ByteString as B
+import qualified Data.ByteString           as B
+import qualified Data.ByteString.Char8     as B8
+
+-- | ad-hoc structure for not confuse the args
+data DCCOffer = DCCOffer
+     { doName :: B.ByteString
+     , doAddr :: B.ByteString
+     , doPort :: B.ByteString
+     , doSize :: B.ByteString
+     }
+
+data DCCError = ParseIPPort
+              | ParseDottedIP
+              | FailGetAdrr -- ^ inet_ntoa
+              | NotFullRecv Int -- ^ Bytes that are missing
+  deriving (Eq, Show)
+
+type DottedIP = String
+type IPPort   = String
+
+-- Binary utilities
+
+-- | Given a Word32 ie 4 chained bytes (a,b,c,d) return the reverse of
+-- such chain (d,c,b,a). Useful for the network byte order IP on the CTCP
+-- DCC message
+complement :: HostAddress -> HostAddress
+complement h =
+  let (a,b,c,d) = (h .&. 0xFF000000, h .&. 0xFF0000, h .&. 0xFF00, h .&. 0xFF)
+   in (rotateR d 8) + (rotateL c 8) + (rotateR b 8) + (rotateL a 8)
+
+-- | Utility function for parsing Port, file size and HostAddress. For this
+-- last one we need Num because we rely on its instance for construction.
+parseBS :: (Num a) => B.ByteString -> Maybe a
+parseBS = fmap (fromInteger . fst) . B8.readInteger
+
+parseDccIP :: DCCOffer -> ExceptT DCCError IO (DottedIP, IPPort)
+parseDccIP (DCCOffer _ bAddr bPort _)
+  | Just addr   <- parseBS bAddr =
+        lift $ do dottedIP <- inet_ntoa (complement addr)
+                  return (dottedIP, B8.unpack bPort)
+  | otherwise = throwE ParseIPPort
+
+-- todo slack
+newFileHandle :: String -> IO IO.Handle
+newFileHandle name = IO.openFile ("~/" ++ name) IO.WriteMode
+
+newSocket :: AddrInfo -> IO Socket
+newSocket addr = do
+     sock <- socket AF_INET Stream defaultProtocol
+     connect sock (addrAddress addr)
+     return sock
+
+-- | given a number forms a bytestring with each digit on a separated Word8
+int2BS :: Word -> B.ByteString
+int2BS n = let go b = rotateR n (b * 8) .&. 0xFF
+            in B.pack . map go $ [0,1,2,3]
+
+partnerInfo :: (DottedIP, IPPort) -> ExceptT DCCError IO AddrInfo
+partnerInfo (dottedIP, ipPort) =
+  let flags = [AI_NUMERICHOST, AI_NUMERICSERV]
+      hints = defaultHints { addrFlags = flags }
+   in lift (getAddrInfo (Just hints) (Just dottedIP) (Just ipPort))
+      >>= maybe (throwE FailGetAdrr) return . preview folded
+
+getPackets :: String   -- ^ Name media
+           -> Int      -- ^ File size
+           -> AddrInfo
+           -> ExceptT DCCError IO ()
+getPackets name totalSize addr =
+  do receivedSize <- lift $ bracket (acquire) (uncurry release)
+                                    (uncurry receive)
+     let delta = (totalSize - receivedSize)
+     if delta > 0 then throwE (NotFullRecv delta) else return ()
+  where
+    bufferSize = 4096
+
+    acquire :: IO (IO.Handle, Socket)
+    acquire = (,) <$> newFileHandle name <*> newSocket addr
+
+    release :: IO.Handle -> Socket -> IO ()
+    release hdl sock = IO.hClose hdl >> close sock)
+
+    receive :: IO.Handle -> Socket -> IO Int
+    receive hdl sock =
+        flip execState 0 . fix $ \loop -> do
+            mediaData <- lift (B.recv sock bufferSize)
+            if (B.null mediaData)
+              then return () -- we only care about the state
+              else do S.modify' (+ (B.length mediaData))
+                      currentSize <- S.get
+                      lift $ B.hPut hdl mediaData
+                             >> B.send sock (int2BS currentSize)
+                      loop
+
+dcc_recv :: DCCOffer -> IO ()
+dcc_recv offer@(DCCOffer bName _ _ bSize) =
+  let size = read (B8.unpack bSize)
+      name = B8.unpack bName
+   in void . runExceptT $
+          parseDccIP offer
+          >>= partnerInfo
+          >>= liftIO . getPackets name size

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -117,6 +117,7 @@ parseDccIP (DCCOffer _ bAddr bPort _)
 newSocket :: AddrInfo -> IO Socket
 newSocket addr = do
      sock <- socket AF_INET Stream defaultProtocol
+     setSocketOption sock NoDelay 1
      connect sock (addrAddress addr)
      return sock
 
@@ -153,7 +154,7 @@ getPackets mvar name totalSize addr =
                 S.modify' (+ (B.length mediaData))
                 currentSize <- S.get
                 lift $ B.hPut hdl mediaData
-                       >> B.send sock (int2BS currentSize)
+                       >> B.sendAll sock (int2BS currentSize)
                        >> swapMVar mvar currentSize
                 loop
 

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -2,6 +2,7 @@
 module DCC where
 
 import           Prelude        hiding (getContents, log)
+import           Control.Applicative   ((<$>), (<*>))
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.State as S
 import           Control.Monad.Trans.Except

--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -117,7 +117,10 @@ main = do
                , _clientTimeZone        = zone
                }
        st1 <- schedulePing st0
-       forkIO . void $ dccDownloadManager dccChan
+       let Just outpath = preview ( cmdArgConfigValue . C.key "download-dir"
+                                    . C.text . Text.unpacked ) args
+                          `mplus` (Just "~/")
+       forkIO . void $ dccDownloadLoop outpath dccChan
 
        driver vty vtyEventChan recvChan st1
 

--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -753,11 +753,11 @@ doChannelInfoCmd st
   where
   conn = view (clientServer0 . ccConnection) st
 
--- todo(slack) just debug
 doDccTransfers :: ClientState -> IO ClientState
-doDccTransfers st
-    | Just chan <- focusedChan st = return $ set clientFocus (DCCFocus chan) st
-    | otherwise = return st
+doDccTransfers st =
+  case view clientFocus st of
+    DCCFocus _ -> return $ st   -- No DCCFocus (DCCFocus (..))
+    oldFocus -> return $ set clientFocus (DCCFocus oldFocus) st
 
 doMasksCmd ::
   Char       {- ^ mode    -} ->

--- a/driver/Views/DCC.hs
+++ b/driver/Views/DCC.hs
@@ -1,0 +1,33 @@
+module Views.DCC where
+
+import ClientState
+import Control.Lens
+import Data.ByteString (ByteString)
+import Data.List (partition)
+import Data.Map (Map)
+import Data.Monoid
+import Graphics.Vty.Image
+import ImageUtils
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map as Map
+
+import Irc.Format
+import Irc.Model
+import DCC
+
+dccImage :: ClientState -> [Image]
+dccImage st = undefined
+-- dccImage st = foldr (\a acc -> progressImage a : acc) emptyImage
+--                     (view clientDCCTransfer st)
+
+progressImage :: Transfer -> Image
+progressImage (Ongoing name total current _ _) =
+    string defAttr name <|>
+    string (withForeColor defAttr blue) (percent total current)
+progressImage (Finished name size) =
+    string defAttr name <|>
+    string (withForeColor defAttr green) "100"
+
+percent :: Int -> Int -> String
+percent total current =
+  show $ ((fromIntegral current) / (fromIntegral total)) * 100

--- a/driver/Views/DCC.hs
+++ b/driver/Views/DCC.hs
@@ -16,9 +16,7 @@ import Irc.Model
 import DCC
 
 dccImage :: ClientState -> [Image]
-dccImage st = undefined
--- dccImage st = foldr (\a acc -> progressImage a : acc) emptyImage
---                     (view clientDCCTransfer st)
+dccImage = map progressImage . view clientDCCTransfers
 
 progressImage :: Transfer -> Image
 progressImage (Ongoing name total current _ _) =
@@ -26,8 +24,9 @@ progressImage (Ongoing name total current _ _) =
     string (withForeColor defAttr blue) (percent total current)
 progressImage (Finished name size) =
     string defAttr name <|>
-    string (withForeColor defAttr green) "100"
+    string (withForeColor defAttr green) " 100"
 
 percent :: Int -> Int -> String
 percent total current =
-  show $ ((fromIntegral current) / (fromIntegral total)) * 100
+  let value = ((fromIntegral current) / (fromIntegral total)) * 100
+  in ' ' : (take 5 . show $ value)

--- a/irc-core.cabal
+++ b/irc-core.cabal
@@ -128,6 +128,7 @@ executable glirc
                  Views.BanList
                  Views.Channel
                  Views.ChannelInfo
+                 Views.DCC
                  Paths_irc_core
   hs-source-dirs: driver
   ghc-options: -threaded

--- a/irc-core.cabal
+++ b/irc-core.cabal
@@ -120,6 +120,7 @@ executable glirc
                  ConnectCmds
                  CtcpHandler
                  EditBox
+                 DCC
                  HaskellHighlighter
                  ImageUtils
                  Moderation


### PR DESCRIPTION
These are many patches. If you want I can squeeze them.

I implemented the DCC protocol as described in [here](http://www.kvirc.net/doc/doc_dcc_connection.html). To do so I basically did the following

- Added a module driver/DCC.hs which set up the sockets for the transfers and defines a `DCCOffer` ADT because the socket API is kind of stringly-typed (underlying C).
- Added on CtcpHandler.hs a new handler `dccHandler` which listen to offers, packs them up in `DCCOffer` and stores them in `ClientConnection` 's `ccHoldDccTrans` which is a `Data.Map` associating `Identifier`s (senders) to their single `DCCOffer`.
- Per the original CtcpHandler on the same message a new window is open on the UI. On such the user will be reported of a new offer and told he can issue `/dcc accept` or `/dcc cancel` commands, each doing the obvious.
- In case of `/dcc accept` the `DCCOffer` is promoted to a `Transfer` defined in DCC.hs which is an ADT with display information and a `MVar` (only for reading) to update the % of completion. It is also move to a more 'UI centric' layer in `ClientState` at `clientDCCTransfers`.
- The progress is shown on a new special `Focus` called `DCCFocus` which is triggered with the command `/transfers`. This is really basic ATM.

I will update part of this soon, in particular the `DCCFocus` windows maybe needs to be updated regularly and not on each `driver` call (I made a hack on `continue` for this). I had set up a type `DCCError` but I don't act nor report on it and I need to add cancel options for currently started downloads.