### PR TITLE
Add forward deletion of words (bound to M-DEL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,12 @@ Keyboard Shortcuts
 * `^K` delete to end
 * `^U` delete to beginning
 * `^D` delete at cursor
-* `^W` delete word
+* `^W` delete word backwards
 * `^Y` paste from yank buffer
 * `M-F` forward word
 * `M-B` backward word
+* `M-BACKSPACE` delete word backwards
+* `M-D` delete word forwards
 * `TAB` nickname completion
 * `F2` toggle detailed view
 * `Page Up` scroll up

--- a/src/Client/EditBox.hs
+++ b/src/Client/EditBox.hs
@@ -33,7 +33,8 @@ module Client.EditBox
   , end
   , killHome
   , killEnd
-  , killWord
+  , killWordBackward
+  , killWordForward
   , paste
   , left
   , right
@@ -356,8 +357,8 @@ paste e = over content (insertString (view yankBuffer e)) e
 
 -- | Kill the content from the cursor back to the previous word boundary.
 -- When @yank@ is set the yank buffer will be updated.
-killWord :: Bool {- ^ yank -} -> EditBox -> EditBox
-killWord yank e
+killWordBackward :: Bool {- ^ yank -} -> EditBox -> EditBox
+killWordBackward yank e
   = sometimesUpdateYank
   $ set (content.current) (Line (length l') (l'++r))
   $ e
@@ -368,6 +369,24 @@ killWord yank e
   (wd,l2) = break isSpace l1
   l' = reverse l2
   yanked = reverse (sp++wd)
+
+  sometimesUpdateYank
+    | yank = updateYankBuffer yanked
+    | otherwise = id
+
+-- | Kill the content from the curser forward to the next word boundary.
+-- When @yank@ is set the yank buffer will be updated
+killWordForward :: Bool {- ^ yank -} -> EditBox -> EditBox
+killWordForward yank e
+  = sometimesUpdateYank
+  $ set (content.current) (Line (length l) (l++r2))
+  $ e
+  where
+  Line n txt = view (content.current) e
+  (l,r) = splitAt n txt
+  (sp,r1) = span  isSpace r
+  (wd,r2) = break isSpace r1
+  yanked = sp++wd
 
   sometimesUpdateYank
     | yank = updateYankBuffer yanked

--- a/src/Client/EventLoop.hs
+++ b/src/Client/EventLoop.hs
@@ -288,7 +288,7 @@ doKey key modifier st =
         KChar 'u' -> changeEditor Edit.killHome
         KChar 'k' -> changeEditor Edit.killEnd
         KChar 'y' -> changeEditor Edit.paste
-        KChar 'w' -> changeEditor (Edit.killWord True)
+        KChar 'w' -> changeEditor (Edit.killWordBackward True)
         KChar 'b' -> changeEditor (Edit.insert '\^B')
         KChar 'c' -> changeEditor (Edit.insert '\^C')
         KChar ']' -> changeEditor (Edit.insert '\^]')
@@ -303,7 +303,8 @@ doKey key modifier st =
     [MMeta] ->
       case key of
         KEnter    -> changeEditor (Edit.insert '\^J')
-        KBS       -> changeEditor (Edit.killWord True)
+        KBS       -> changeEditor (Edit.killWordBackward True)
+        KChar 'd' -> changeEditor (Edit.killWordForward True)
         KChar 'b' -> changeContent Edit.leftWord
         KChar 'f' -> changeContent Edit.rightWord
         KChar 'a' -> eventLoop (jumpToActivity st)

--- a/src/Client/WordCompletion.hs
+++ b/src/Client/WordCompletion.hs
@@ -55,7 +55,7 @@ wordComplete leadingCase isReversed vals box =
 
 replaceWith :: (String -> String) -> String -> Edit.EditBox -> Edit.EditBox
 replaceWith leadingCase str box =
-    let box1 = Edit.killWord False box
+    let box1 = Edit.killWordBackward False box
         str1 | view Edit.pos box1 == 0 = leadingCase str
              | otherwise               = str
     in over Edit.content (Edit.insertString str1) box1


### PR DESCRIPTION
I realize that you might not want to add all kinds of movement operators and have `glirc` become emacs, but this seems simple enough and only consistent if we have backwards killing of words. The shortcut is the standard emacs shortcut.