### PR TITLE
Cancel transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Learn more about this file format at [config-value](http://hackage.haskell.org/p
 ```
 -- Optional file to dump raw server messages
 debug-file: "debug.txt"
+download-dir: "~/downloads"
 
 -- Defaults used when not specified on command line
 defaults:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ DCC commands
 
 * `/transfers` - Show the DCC Offers and the ongoing progress
 * `/dcc accept` - On the sender window starts the download
-* `/dcc cancel` - as above but drops the offer and informs the sender with xdcc cancel
+* `/dcc cancel` - as above but drops the offer/transfer
 
 Keyboard Shortcuts
 ==================

--- a/driver/CtcpHandler.hs
+++ b/driver/CtcpHandler.hs
@@ -109,7 +109,7 @@ queueOffer outDir _ msg st =
     -- Store the offer until the user accepts it on /dcc accept
     storeOffer :: FourTuple ByteString -> ClientState
     storeOffer offer =
-      set (clientServer0 . ccHoldDccTrans . at sender)
+      set (clientServer0 . ccHoldDccTrans . _1 . at sender)
           (Just (parseDccOffer ctime outDir offer)) st
 
 -- todo(slack): better message to the user (this is a hack)
@@ -117,6 +117,7 @@ queueOffer outDir _ msg st =
 userConfirm :: Identifier -> ClientState -> ClientState
 userConfirm sender st =
   let questionText =
-        PrivMsgType $ "You have a pending DCC transfer. Issue "
-                       <>  "/dcc accept or /dcc cancel"
-  in addMessage sender (set mesgType questionText defaultIrcMessage) st
+        "You have a pending DCC transfer from this sender. Issue /dcc "
+        <> "accept or /dcc cancel. If started, you can issue /dcc cancel "
+        <> "to stop the transfer from this window"
+  in addMessage sender (set mesgType (PrivMsgType questionText) defaultIrcMessage) st

--- a/driver/CtcpHandler.hs
+++ b/driver/CtcpHandler.hs
@@ -82,9 +82,10 @@ dccHandler outDir = EventHandler
 
 queueOffer :: FilePath -> Identifier -> IrcMessage
            -> ClientState -> ClientState
-queueOffer outDir _ msg st = fromJust $
-    (notIgnored >> isCtcpMsg >>= isDCCcommand
-     >>= pure . userConfirm sender . storeOffer) <|> Just st
+queueOffer outDir _ msg st =
+  fromMaybe st $
+    notIgnored >> isCtcpMsg >>= isDCCcommand
+    >>= pure . userConfirm sender . storeOffer
   where
     space = 0x20
     sender = views mesgSender userNick msg

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -41,15 +41,15 @@ data Transfer =
       , _tSize     :: Int
       , _tcurSize  :: Int
       , _threadId  :: ThreadId
-      , _tProgress :: MVar Int }
+      , _tProgress :: Progress }
   | Finished
       { _tName :: FilePath
       , _tSize :: Int }
 
-makeLenses ''Transfer
-
 -- current size of transfer.
 type Progress = MVar Int
+
+makeLenses ''Transfer
 
 data DCCError = ParseIPPort
               | ParseDottedIP

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -24,6 +24,8 @@ import qualified Network.Socket.ByteString as B
 import qualified Data.ByteString           as B
 import qualified Data.ByteString.Char8     as B8
 
+import Irc.Format (Identifier)
+
 -- | ad-hoc structure for not confuse the args, only the name and size
 -- are processed the C functions underlying expect Bytestrings and not
 -- value as input
@@ -43,8 +45,12 @@ data Transfer =
       , _threadId  :: ThreadId
       , _tProgress :: Progress }
   | Finished
-      { _tName :: FilePath
-      , _tSize :: Int }
+      { _tName   :: FilePath
+      , _tSize   :: Int }
+  | Failed
+      { _tName    :: FilePath
+      , _tSize    :: Int
+      , _tcurSize :: Int }
 
 -- current size of transfer.
 type Progress = MVar Int

--- a/driver/DCC.hs
+++ b/driver/DCC.hs
@@ -64,7 +64,7 @@ type FourTuple a = (a, a, a, a)
 -- Smart constructor
 parseDccOffer :: UTCTime -> FilePath -> FourTuple B.ByteString -> DCCOffer
 parseDccOffer ctime outDir (bName, bAddr, bPort, bSize) =
-    let fullpath = outDir ++ "/" ++ (B8.unpack bName)
+    let fullpath = outDir </> (B8.unpack bName) -- handles trailing /
         size     = read (B8.unpack bSize)
      in DCCOffer fullpath bAddr bPort size ctime
 

--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -755,9 +755,10 @@ doChannelInfoCmd st
 
 doDccTransfers :: ClientState -> IO ClientState
 doDccTransfers st =
-  case view clientFocus st of
-    DCCFocus _ -> return $ st   -- No DCCFocus (DCCFocus (..))
-    oldFocus -> return $ set clientFocus (DCCFocus oldFocus) st
+  return . clearInput $
+    case view clientFocus st of
+      DCCFocus _ -> st   -- No recursive DCCFocus
+      oldFocus   -> set clientFocus (DCCFocus oldFocus) st
 
 doMasksCmd ::
   Char       {- ^ mode    -} ->

--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -114,7 +114,6 @@ main = do
                , _clientNickColors      = defaultNickColors
                , _clientAutomation      = [dccHandler outDir, ctcpHandler
                                           ,cancelDeopTimerOnDeop, connectCmds]
-               , _clientDCCTransfers    = mempty
                , _clientTimers          = mempty
                , _clientTimeZone        = zone
                }
@@ -161,7 +160,7 @@ startIrcConnection recvChan settings hErr =
          , _ccSendChan       = Just (connectedRef, sendChan)
          , _ccRecvThread     = Just recvThreadId
          , _ccSendThread     = Just sendThreadId
-         , _ccHoldDccTrans   = Map.empty
+         , _ccHoldDccTrans   = (Map.empty, Map.empty)
          }
 
   connectionFailed (SomeException e) =
@@ -177,7 +176,7 @@ startIrcConnection recvChan settings hErr =
          , _ccSendChan       = Nothing
          , _ccRecvThread     = Nothing
          , _ccSendThread     = Nothing
-         , _ccHoldDccTrans   = Map.empty
+         , _ccHoldDccTrans   = (Map.empty, Map.empty)
          }
 
 initializeConnection ::
@@ -446,10 +445,10 @@ commandEvent st = commandsParser (clientInput st)
  dccCommand :: (String, [String], Parser (IO KeyEventResult))
  dccCommand =
    let popAndLaunch = fmap (fmap KeepGoing) $ startOffer st'
-       justPop      = fmap (fmap KeepGoing) $ cancelOffer st'
+       popOrKill    = fmap (fmap KeepGoing) $ cancelOffer st'
        cmdBranch a = case a of
                        "accept" -> popAndLaunch
-                       "cancel" -> justPop
+                       "cancel" -> popOrKill
                        _        -> Nothing
 
     in ("dcc", [], pValidToken "(accept|cancel)" cmdBranch )

--- a/driver/Views/DCC.hs
+++ b/driver/Views/DCC.hs
@@ -1,10 +1,11 @@
-module Views.DCC (dccImage) where
+module Views.DCC  where
 
 import qualified Data.Map as Map
 import System.FilePath
 import Data.Text.Encoding
 import Control.Lens
 import Graphics.Vty.Image
+import Text.Printf
 
 import ClientState
 import DCC
@@ -27,15 +28,17 @@ offerImg (ident, offer) =
   <|> text' defAttr (decodeUtf8 (idBytes ident))
 
 transferImg :: Transfer -> Image
-transferImg (Ongoing name total current _ _) =
-    string defAttr name <|>
-    string (withForeColor defAttr blue) (percent total current)
-transferImg (Finished name _) =
-    string defAttr name <|>
-    char defAttr ' ' <|>
-    string (withForeColor defAttr green) "100"
+transferImg trans = string defAttr name <|>
+                    pad (max 1 (70 - length name)) 0 0 0 (context trans)
+  where
+    name = _tName trans
+
+    context (Finished _ _) = string (withForeColor defAttr green) "100%"
+    context (Ongoing _ total current _ _) =
+      string (withForeColor defAttr blue) (percent total current)
 
 percent :: Int -> Int -> String
 percent total current =
-  let value = ((fromIntegral current) / (fromIntegral total)) * 100
-  in ' ' : (take 5 . show $ value)
+  let value :: Double
+      value = ((fromIntegral current) / (fromIntegral total)) * 100
+  in printf "%.1f%%" value

--- a/driver/Views/DCC.hs
+++ b/driver/Views/DCC.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
 module Views.DCC  where
 
 import qualified Data.Map as Map
@@ -14,9 +15,10 @@ import Irc.Format
 
 dccImage :: ClientState -> [Image]
 dccImage st =
-  concat [ map transferImg . view clientDCCTransfers $ st
-         , map offerImg . Map.assocs . view (clientServer0 . ccHoldDccTrans) $ st
+  concat [ map transferImg . Map.assocs . view (focus . _2) $ st
+         , map offerImg . Map.assocs . view (focus . _1) $ st
          ]
+  where focus = clientServer0 . ccHoldDccTrans
 
 offerImg :: (Identifier, DCCOffer) -> Image
 offerImg (ident, offer) =
@@ -27,13 +29,18 @@ offerImg (ident, offer) =
   <|> string defAttr " from "
   <|> text' defAttr (decodeUtf8 (idBytes ident))
 
-transferImg :: Transfer -> Image
-transferImg trans = string defAttr name <|>
-                    pad (max 1 (70 - length name)) 0 0 0 (context trans)
+transferImg :: (Identifier, Transfer) -> Image
+transferImg (ident, trans) =
+  string defAttr name
+  <|> pad (max 1 (70 - length name)) 0 0 0 (context trans)
+  <|> string defAttr " from "
+  <|> text' defAttr (decodeUtf8 (idBytes ident))
   where
     name = _tName trans
 
     context (Finished _ _) = string (withForeColor defAttr green) "100%"
+    context (Failed _ total current) =
+      string (withForeColor defAttr red) (percent total current)
     context (Ongoing _ total current _ _) =
       string (withForeColor defAttr blue) (percent total current)
 


### PR DESCRIPTION
I had some tidy up to do on the DCC code and setting the documentation correct. I also changed the semantics of what it means to cancel a DCC transfers. Before I incorrectly assumed each of them came from a XDCC exchange, which is not true. I also made the `/dcc cancel` command kill the already started download.
