### PR TITLE
Implement padding of nicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Configuration sections:
 * `servers` - These settings are used to override defaults when the hostname matches
 * `palette` - Client color overrides
 * `window-names` - text - Names of windows (typically overridden on non QWERTY layouts)
+* `nick-padding` - nonnegative integer - Nicks are padded until they have the specified length
 
 Settings
 --------

--- a/src/Client/Configuration.hs
+++ b/src/Client/Configuration.hs
@@ -22,6 +22,7 @@ module Client.Configuration
   , configServers
   , configPalette
   , configWindowNames
+  , configNickPadding
 
   -- * Loading configuration
   , loadConfiguration
@@ -38,6 +39,7 @@ import           Control.Monad
 import           Config
 import           Config.FromConfig
 import           Control.Lens hiding (List)
+import           Data.Foldable (for_)
 import           Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import           Data.Maybe
@@ -57,7 +59,8 @@ data Configuration = Configuration
   { _configDefaults :: ServerSettings -- ^ Default connection settings
   , _configServers  :: (HashMap Text ServerSettings) -- ^ Host-specific settings
   , _configPalette  :: Palette
-  , _configWindowNames :: Text -- ^ Names of windows, used when alt-jumping
+  , _configWindowNames :: Text -- ^ Names of windows, used when alt-jumping)
+  , _configNickPadding :: Maybe Integer -- ^ Padding of nicks
   }
   deriving Show
 
@@ -159,6 +162,12 @@ parseConfiguration def = parseSections $
 
      _configWindowNames <- fromMaybe defaultWindowNames
                     <$> sectionOpt "window-names"
+
+     _configNickPadding <- sectionOpt "nick-padding"
+     for_ _configNickPadding (\padding ->
+       when (padding < 0)
+            (liftConfigParser $
+               failure "nick-padding has to be a non negative number"))
 
      return Configuration{..}
 

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -238,6 +238,7 @@ recordChannelMessage network channel msg st =
       , rendNicks      = channelUserList network channel' st
       , rendMyNicks    = myNicks
       , rendPalette    = palette
+      , rendNickPadding = view (clientConfig . configNickPadding) st
       }
 
     palette = view (clientConfig . configPalette) st


### PR DESCRIPTION
This is a simple implementation that simply pads up to the specified length and nicks longer than that overflow, but at least I am happy with it for now. We can always come up with a more complex implementation, like padding up to the name of the longest nick in the buffer later on.