### PR TITLE
Filter current nick from completion hints

### DIFF
--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -986,9 +986,14 @@ activeNicks st =
         . winMessages      . folded
         . wlBody           . _IrcBody
         . folding msgActor . to userNick
-        . filtered isActive) st
+        . filtered isActive
+        . filtered isNotSelf ) st
       where
         isActive n = HashMap.member n userMap
+        self = preview ( clientConnection network . csNick ) st
+        isNotSelf n = case self of
+                        Nothing -> True
+                        Just s -> n /= s
         userMap = view ( clientConnection network
                        . csChannels . ix channel
                        . chanUsers) st


### PR DESCRIPTION
Not sure what your opinion on this is (we discussed it at some point but I forgot). We could make it an option but completing your nick because you recently talked seems unlikely.
