### PR TITLE
Tweak cabal file

### DIFF
--- a/glirc.cabal
+++ b/glirc.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                glirc
 version:             2.28
 synopsis:            Console IRC client
@@ -13,19 +14,17 @@ author:              Eric Mertens
 maintainer:          emertens@gmail.com
 copyright:           2016,2017 Eric Mertens
 category:            Network
-build-type:          Custom
 extra-source-files:  ChangeLog.md README.md
                      exec/linux_exported_symbols.txt
                      exec/macos_exported_symbols.txt
-cabal-version:       >=1.23
 homepage:            https://github.com/glguy/irc-core
 bug-reports:         https://github.com/glguy/irc-core/issues
-tested-with:         GHC==8.0.2
+tested-with:         GHC==8.4.3
 
 custom-setup
   setup-depends: base     >=4.11 && <4.12,
                  filepath >=1.4  && <1.5,
-                 Cabal    >=1.24 && <2.3
+                 Cabal    >=2.2  && <2.3,
 
 source-repository head
   type: git
@@ -124,6 +123,9 @@ library
                        Paths_glirc
                        Build_glirc
 
+  autogen-modules:     Paths_glirc
+                       Build_glirc
+
   build-depends:       base                 >=4.11   && <4.12,
                        HsOpenSSL            >=0.11   && <0.12,
                        async                >=2.1    && <2.3,
@@ -155,7 +157,7 @@ library
                        unix                 >=2.7    && <2.8,
                        unordered-containers >=0.2.7  && <0.3,
                        vector               >=0.11   && <0.13,
-                       vty                  >=5.23.1 && <5.24
+                       vty                  >=5.23.1 && <5.24,
 
 test-suite test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Most importantly, this fixes the missing `autogen-modules` for the
autogenerated Build_ and Paths_ files; this is needed by `cabal new-sdist`
as it needs this information to operate correctly.

Moreover, since only GHC 8.4.3 is supported (which requires cabal 2.2 or later)
we can upgrade to cabal-version:2.2 and benefit from some minor improvements
(build-type is inferred; redundant trailing commas)