### PR TITLE
glirc.cabal: bump regex-tdfa dependency version to 1.3.1

### DIFF
--- a/glirc.cabal
+++ b/glirc.cabal
@@ -24,7 +24,7 @@ tested-with:         GHC==8.6.5
 custom-setup
   setup-depends: base     >=4.12 && <4.14,
                  filepath >=1.4  && <1.5,
-                 Cabal    >=2.2  && <4,
+                 Cabal    >=2.2  && <4
 
 source-repository head
   type: git
@@ -158,7 +158,7 @@ library
                        network              >=2.6.2  && <3.2,
                        process              >=1.4.2  && <1.7,
                        psqueues             >=0.2.7  && <0.3,
-                       regex-tdfa           >=1.3    && <1.4,
+                       regex-tdfa           >=1.3.1  && <1.4,
                        semigroupoids        >=5.1    && <5.4,
                        split                >=0.2    && <0.3,
                        stm                  >=2.4    && <2.6,
@@ -169,7 +169,7 @@ library
                        unix                 >=2.7    && <2.8,
                        unordered-containers >=0.2.7  && <0.3,
                        vector               >=0.11   && <0.13,
-                       vty                  >=5.23.1 && <5.27,
+                       vty                  >=5.23.1 && <5.27
 
 test-suite test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
glirc fails to build against regex-tdfa-1.3 since it cannot find
the module Text.Regex.TDFA.Text, which was introduced in regex-tdfa-1.3.1.

Bump the lower bound on the regex-tdfa dependency to 1.3.1 to fix this issue.

Also remove trailing commas from setup-depends and build-depends, which were
causing issues for Gentoo Haskell's maintenance automation tool HackPort.