### PR TITLE
Remove AI_ADDRCONFIG flag from getAddrInfo hints

### DIFF
--- a/hookup/src/Hookup.hs
+++ b/hookup/src/Hookup.hs
@@ -266,7 +266,7 @@ openSocket' h p mbBind =
 hints :: AddrInfo
 hints = Socket.defaultHints
   { Socket.addrSocketType = Socket.Stream
-  , Socket.addrFlags      = [Socket.AI_ADDRCONFIG, Socket.AI_NUMERICSERV]
+  , Socket.addrFlags      = [Socket.AI_NUMERICSERV]
   }
 
 resolve :: Maybe PortNumber -> HostName -> IO [AddrInfo]


### PR DESCRIPTION
Do not use AI_ADDRCONFIG flag in getAddrInfo hints as it cannot handle '127.0.0.1' on IPv6-only machines.