### PR TITLE
Add Matterbridge hook

### DIFF
--- a/glirc.cabal
+++ b/glirc.cabal
@@ -91,6 +91,7 @@ library
                        Client.EventLoop.Network
                        Client.Hook
                        Client.Hook.DroneBLRelay
+                       Client.Hook.Matterbridge
                        Client.Hook.Snotice
                        Client.Hook.Znc.Buffextras
                        Client.Hooks

--- a/src/Client/Hook/Matterbridge.hs
+++ b/src/Client/Hook/Matterbridge.hs
@@ -1,0 +1,59 @@
+{-# Language OverloadedStrings #-}
+{-|
+Module      : Client.Hook.Matterbridge
+Description : Hook for intergrating Matterbridge bridged messages
+Copyright   : (c) Felix Friedlander 2021
+License     : ISC
+Maintainer  : felix@ffetc.net
+
+Matterbridge is a simple multi-protocol chat bridge, supporting
+dozens of different protocols. This hook makes Matterbridged messages
+appear native in the client.
+
+message-hooks configuration takes the following form:
+
+> ["matterbridge", "nick", "#chan1", "#chan2", ..., "#chann"]
+
+This hook assumes the Matterbridge RemoteNickFormat is simply
+"<{NICK}> ".
+
+-}
+module Client.Hook.Matterbridge (matterbridgeHook) where
+
+import Data.Text (Text)
+
+import Control.Lens (set, view)
+
+import Text.Regex.TDFA ((=~))
+
+import Client.Hook (MessageHook(..), MessageResult(..))
+import Irc.Message
+import Irc.Identifier (mkId, Identifier)
+import Irc.UserInfo (UserInfo(..), uiNick)
+
+data MbMsg = Msg | Act
+
+matterbridgeHook :: [Text] -> Maybe MessageHook
+matterbridgeHook (nick:chans) = Just $ MessageHook "matterbridge" False $ remap (mkId nick) (map mkId chans)
+matterbridgeHook _ = Nothing
+
+remap :: Identifier -> [Identifier] -> IrcMsg -> MessageResult
+remap nick chans ircmsg = case ircmsg of
+  (Privmsg (Source ui _) chan msg)
+    | view uiNick ui == nick, chan `elem` chans -> remap' Msg ui chan msg
+  (Ctcp (Source ui _) chan "ACTION" msg)
+    | view uiNick ui == nick, chan `elem` chans -> remap' Act ui chan msg
+  _ -> PassMessage
+
+remap' :: MbMsg -> UserInfo -> Identifier -> Text -> MessageResult
+remap' mbmsg ui chan msg
+  | (_,_,_,[nick,msg']) <- msg =~ ("^<([^>]+)> (.*)$" :: Text) :: (Text, Text, Text, [Text])
+  = RemapMessage $ newmsg mbmsg (fakeUser ui nick) chan msg'
+  | otherwise = PassMessage
+
+newmsg :: MbMsg -> Source -> Identifier -> Text -> IrcMsg
+newmsg Msg src chan msg = Privmsg src chan msg
+newmsg Act src chan msg = Ctcp src chan "ACTION" msg
+
+fakeUser :: UserInfo -> Text -> Source
+fakeUser ui nick = Source (set uiNick (mkId nick) ui) ""

--- a/src/Client/Hooks.hs
+++ b/src/Client/Hooks.hs
@@ -20,6 +20,7 @@ import Data.HashMap.Strict
 import Client.Hook
 
 import Client.Hook.DroneBLRelay
+import Client.Hook.Matterbridge
 import Client.Hook.Snotice
 import Client.Hook.Znc.Buffextras
 
@@ -29,4 +30,5 @@ messageHooks = fromList
   [ ("snotice", \_ -> Just snoticeHook)
   , ("droneblrelay", droneblRelayHook)
   , ("buffextras", buffextrasHook)
+  , ("matterbridge", matterbridgeHook)
   ]


### PR DESCRIPTION
This hook reinterprets messages from a [Matterbridge][1]'s nick as their IRC-native counterparts.

[1]: https://github.com/42wim/matterbridge