### PR TITLE
Implement better away status handling

### DIFF
--- a/src/Client/Image/Message.hs
+++ b/src/Client/Image/Message.hs
@@ -239,6 +239,7 @@ ircLinePrefix !rp body =
     Ping       {} -> mempty
     Pong       {} -> mempty
     Nick       {} -> mempty
+    Away       {} -> mempty
 
     -- details in message part
     Topic src _ _  -> who src
@@ -301,6 +302,7 @@ ircLineImage !rp body =
     BatchEnd    {} -> mempty
     Nick        {} -> mempty
     Authenticate{} -> "***"
+    Away        {} -> mempty
 
     Error                   txt -> parseIrcText pal txt
     Topic _ _ txt ->
@@ -516,6 +518,15 @@ fullIrcLineImage !rp body =
       string quietAttr "chng " <>
       who user <> ": " <>
       ctxt newuser <> " " <> ctxt newhost
+
+    Away user (Just txt) ->
+      string quietAttr "away " <>
+      who user <> ": " <>
+      parseIrcTextWithNicks pal hilites False txt
+
+    Away user Nothing ->
+      string quietAttr "back " <>
+      who user
 
 
 renderCapCmd :: CapCmd -> Text
@@ -1185,14 +1196,16 @@ highlightNicks palette hilites txt = foldMap highlight1 txtParts
 metadataImg :: IrcSummary -> Maybe (Image', Identifier, Maybe Identifier)
 metadataImg msg =
   case msg of
-    QuitSummary who _   -> Just (char (withForeColor defAttr red   ) 'x', who, Nothing)
-    PartSummary who     -> Just (char (withForeColor defAttr red   ) '-', who, Nothing)
-    JoinSummary who     -> Just (char (withForeColor defAttr green ) '+', who, Nothing)
-    CtcpSummary who     -> Just (char (withForeColor defAttr white ) 'C', who, Nothing)
-    NickSummary old new -> Just (char (withForeColor defAttr yellow) '>', old, Just new)
-    ChngSummary who     -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
-    AcctSummary who     -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
-    _                   -> Nothing
+    QuitSummary who _     -> Just (char (withForeColor defAttr red   ) 'x', who, Nothing)
+    PartSummary who       -> Just (char (withForeColor defAttr red   ) '-', who, Nothing)
+    JoinSummary who       -> Just (char (withForeColor defAttr green ) '+', who, Nothing)
+    CtcpSummary who       -> Just (char (withForeColor defAttr white ) 'C', who, Nothing)
+    NickSummary old new   -> Just (char (withForeColor defAttr yellow) '>', old, Just new)
+    ChngSummary who       -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
+    AcctSummary who       -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
+    AwaySummary who True  -> Just (char (withForeColor defAttr yellow) 'a', who, Nothing)
+    AwaySummary who False -> Just (char (withForeColor defAttr green ) 'b', who, Nothing)
+    _                     -> Nothing
 
 
 

--- a/src/Client/State/Network.hs
+++ b/src/Client/State/Network.hs
@@ -768,7 +768,7 @@ selectCaps cs offered = (supported `intersect` Map.keys capMap)
       ["multi-prefix", "batch", "znc.in/playback", "znc.in/self-message"
       , "cap-notify", "extended-join", "account-notify", "chghost"
       , "userhost-in-names", "account-tag", "solanum.chat/identify-msg"
-      , "solanum.chat/realhost" ]
+      , "solanum.chat/realhost", "away-notify"]
 
     -- logic for using IRCv3.2 server-time if available and falling back
     -- to ZNC's specific extension otherwise.


### PR DESCRIPTION
Adds support for the away-notify capability in a way that is not absolute noise hell.
Away notifications are sent to the PM window for a user only if one already exists and has messages in it.
They are collapsed down as metadata, using a yellow `a` for away and green `b` for back (could also use `A`/`B` or `G`/`H`).

This PR also changes how RPL_NOWAWAY and RPL_UNAWAY (the numeric replies for when your own away state changes), displaying them as metadata messages for your nick in all channels. This provides better context for determining what was said in any particular buffer during the time when you marked yourself as away.

RPL_AWAY is now a "boring" message. It is handled the same as before, pending a better way to handle whois queries that return it, but it will no longer be considered activity on the network buffer, in order to reduce noise due to chatting with someone who is perma-away.