### PR TITLE
Expand the /list command

### DIFF
--- a/glirc.cabal
+++ b/glirc.cabal
@@ -127,6 +127,7 @@ library
     Client.UserHost
     Client.View
     Client.View.Cert
+    Client.View.ChannelList
     Client.View.ChannelInfo
     Client.View.Digraphs
     Client.View.Help

--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -36,7 +36,6 @@ import Client.State
 import Client.State.Extensions (clientCommandExtension, clientStartExtensions)
 import Client.State.Focus
 import Client.State.Network (csNick, isChannelIdentifier, sendMsg)
-import Client.State.Window (winMessages, wlText)
 import Control.Applicative (liftA2, (<|>))
 import Control.Exception (displayException, try)
 import Control.Lens

--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -507,13 +507,8 @@ cmdUrl st arg =
     Nothing     -> commandFailureMsg "url-opener not configured" st
     Just opener -> doUrlOpen opener (maybe 0 (subtract 1) arg)
   where
-    focus = view clientFocus st
-
-    urls = toListOf ( clientWindows . ix focus . winMessages . each . wlText
-                    . folding urlMatches) st
-
     doUrlOpen opener n =
-      case preview (ix n) urls of
+      case preview (ix n) (map snd (urlList st)) of
         Just url -> openUrl opener (Text.unpack url) st
         Nothing  -> commandFailureMsg "bad url number" st
 

--- a/src/Client/Commands/Channel.hs
+++ b/src/Client/Commands/Channel.hs
@@ -32,7 +32,6 @@ import Irc.Commands (ircInvite, ircKick, ircMode, ircRemove)
 import Irc.Identifier (Identifier, mkId)
 import Irc.Modes
 import Irc.UserInfo (UserInfo(UserInfo), renderUserInfo)
-import LensUtils (setStrict)
 
 channelCommands :: CommandSection
 channelCommands = CommandSection "IRC channel management"
@@ -150,12 +149,6 @@ cmdInvite channelId cs st nick =
               then cs <$ sendMsg cs cmd
               else sendModeration channelId [cmd] cs
      commandSuccessUpdateCS cs' st
-
-commandSuccessUpdateCS :: NetworkState -> ClientState -> IO CommandResult
-commandSuccessUpdateCS cs st =
-  do let network = view csNetwork cs
-     commandSuccess
-       $ setStrict (clientConnection network) cs st
 
 cmdMasks :: ChannelCommand String
 cmdMasks channel cs st rest =

--- a/src/Client/Commands/Types.hs
+++ b/src/Client/Commands/Types.hs
@@ -10,12 +10,13 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Types where
 
 import Client.Commands.Arguments.Spec (Args)
-import Client.State (ClientState, clientErrorMsg)
-import Client.State.Network (NetworkState)
-import Control.Lens (set)
+import Client.State (ClientState, clientErrorMsg, clientConnection)
+import Client.State.Network (NetworkState, csNetwork)
+import Control.Lens (set, view)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Irc.Identifier (Identifier)
+import LensUtils (setStrict)
 
 -- | Possible results of running a command
 data CommandResult
@@ -75,6 +76,14 @@ data CommandSection = CommandSection
 -- | Consider the text entry successful and resume the client
 commandSuccess :: Monad m => ClientState -> m CommandResult
 commandSuccess = return . CommandSuccess
+
+-- | Consider the text entry successful, and resume the client with
+-- a particular network updated.
+commandSuccessUpdateCS :: NetworkState -> ClientState -> IO CommandResult
+commandSuccessUpdateCS cs st =
+  do let network = view csNetwork cs
+     commandSuccess
+       $ setStrict (clientConnection network) cs st
 
 -- | Consider the text entry a failure and resume the client
 commandFailure :: Monad m => ClientState -> m CommandResult

--- a/src/Client/Image/Message.hs
+++ b/src/Client/Image/Message.hs
@@ -627,7 +627,6 @@ renderReplyCode pal rm srv code@(ReplyCode w) params =
         RPL_ETRACEFULL   -> etraceFullParamsImage
         RPL_ENDOFTRACE   -> params_2_3_Image
         RPL_ENDOFHELP    -> params_2_3_Image
-        RPL_LIST         -> listParamsImage
         RPL_LINKS        -> linksParamsImage
         RPL_ENDOFLINKS   -> params_2_3_Image
         RPL_PRIVS        -> privsImage
@@ -890,12 +889,6 @@ renderReplyCode pal rm srv code@(ReplyCode w) params =
     awayParamsImage =
       case params of
         [_, nick, txt] -> ctxt nick <> label " msg" <> parseIrcText pal txt
-        _ -> rawParamsImage
-
-    listParamsImage =
-      case params of
-        [_, chan, users, topic] ->
-          ctxt chan <> label " users" <> ctxt users <> label " topic" <> ctxt topic
         _ -> rawParamsImage
 
     linksParamsImage =

--- a/src/Client/Image/StatusLine.hs
+++ b/src/Client/Image/StatusLine.hs
@@ -389,7 +389,7 @@ viewSubfocusLabel pal subfocus =
     FocusIgnoreList   -> Just $ string (view palLabel pal) "ignores"
     FocusRtsStats     -> Just $ string (view palLabel pal) "rtsstats"
     FocusCert{}       -> Just $ string (view palLabel pal) "cert"
-    FocusChanList     -> Just $ string (view palLabel pal) "channels"
+    FocusChanList _ _ -> Just $ string (view palLabel pal) "channels"
     FocusMasks m      -> Just $ mconcat
       [ string (view palLabel pal) "masks"
       , char defAttr ':'

--- a/src/Client/Image/StatusLine.hs
+++ b/src/Client/Image/StatusLine.hs
@@ -389,6 +389,7 @@ viewSubfocusLabel pal subfocus =
     FocusIgnoreList   -> Just $ string (view palLabel pal) "ignores"
     FocusRtsStats     -> Just $ string (view palLabel pal) "rtsstats"
     FocusCert{}       -> Just $ string (view palLabel pal) "cert"
+    FocusChanList     -> Just $ string (view palLabel pal) "channels"
     FocusMasks m      -> Just $ mconcat
       [ string (view palLabel pal) "masks"
       , char defAttr ':'

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -434,6 +434,11 @@ msgImportance msg st =
         -- away notices
         Reply _ RPL_AWAY _     -> WLBoring
 
+        -- list output
+        Reply _ RPL_LISTSTART _ -> WLBoring
+        Reply _ RPL_LIST      _ -> WLBoring
+        Reply _ RPL_LISTEND   _ -> WLBoring
+
         -- channel information
         Reply _ RPL_TOPIC _    -> WLBoring
         Reply _ RPL_INVITING _ -> WLBoring

--- a/src/Client/State/Focus.hs
+++ b/src/Client/State/Focus.hs
@@ -55,7 +55,7 @@ data Subfocus
   | FocusRtsStats    -- ^ Show GHC RTS statistics
   | FocusIgnoreList  -- ^ Show ignored masks
   | FocusCert        -- ^ Show rendered certificate
-  | FocusChanList    -- ^ Show channel list
+  | FocusChanList (Maybe Int) (Maybe Int) -- ^ Show channel list
   deriving (Eq,Show)
 
 -- | Unfocused first, followed by focuses sorted by network.

--- a/src/Client/State/Focus.hs
+++ b/src/Client/State/Focus.hs
@@ -55,6 +55,7 @@ data Subfocus
   | FocusRtsStats    -- ^ Show GHC RTS statistics
   | FocusIgnoreList  -- ^ Show ignored masks
   | FocusCert        -- ^ Show rendered certificate
+  | FocusChanList    -- ^ Show channel list
   deriving (Eq,Show)
 
 -- | Unfocused first, followed by focuses sorted by network.

--- a/src/Client/State/Network.hs
+++ b/src/Client/State/Network.hs
@@ -719,6 +719,9 @@ squelchReply rpl =
     RPL_CREATIONTIME    -> True
     RPL_CHANNEL_URL     -> True
     RPL_NOTOPIC         -> True
+    RPL_LISTSTART       -> True
+    RPL_LIST            -> True
+    RPL_LISTEND         -> True
     _                   -> False
 
 -- | Return 'True' for messages that should be hidden outside of

--- a/src/Client/View.hs
+++ b/src/Client/View.hs
@@ -17,6 +17,7 @@ import Client.Image.PackedImage (Image')
 import Client.State
 import Client.State.Focus
 import Client.View.Cert (certViewLines)
+import Client.View.ChannelList (channelListLines)
 import Client.View.ChannelInfo (channelInfoImages)
 import Client.View.Digraphs (digraphLines)
 import Client.View.Help (helpImageLines)
@@ -53,6 +54,8 @@ viewLines focus subfocus w !st =
     (_, FocusRtsStats)     -> rtsStatsLines (view clientRtsStats st) pal
     (_, FocusIgnoreList)   -> ignoreListLines (view clientIgnores st) pal
     (_, FocusCert)         -> certViewLines st
+    (ChannelFocus network _, FocusChanList) -> channelListLines network w st
+    (NetworkFocus network  , FocusChanList) -> channelListLines network w st
     _ -> chatMessageImages focus w st
   where
     pal = clientPalette st

--- a/src/Client/View.hs
+++ b/src/Client/View.hs
@@ -54,8 +54,10 @@ viewLines focus subfocus w !st =
     (_, FocusRtsStats)     -> rtsStatsLines (view clientRtsStats st) pal
     (_, FocusIgnoreList)   -> ignoreListLines (view clientIgnores st) pal
     (_, FocusCert)         -> certViewLines st
-    (ChannelFocus network _, FocusChanList) -> channelListLines network w st
-    (NetworkFocus network  , FocusChanList) -> channelListLines network w st
+    (ChannelFocus network _, FocusChanList min' max') ->
+      channelListLines network w st (min', max')
+    (NetworkFocus network  , FocusChanList min' max') ->
+      channelListLines network w st (min', max')
     _ -> chatMessageImages focus w st
   where
     pal = clientPalette st

--- a/src/Client/View/ChannelList.hs
+++ b/src/Client/View/ChannelList.hs
@@ -22,6 +22,7 @@ import qualified Data.Text.Lazy as LText
 import           Graphics.Vty.Attributes (defAttr)
 import           Irc.Identifier
 
+-- |
 -- | Render the lines used by the @/list@ command in normal mode.
 channelListLines ::
   Text        {- ^ network              -} ->
@@ -50,8 +51,7 @@ channelListLines' cs width st
                  string defAttr (show (length entries))
 
     entries = chanList^.clsItems
-    entries' = clientFilter st filterOn entries
-    filterOn (chan, _, topic) = LText.fromChunks [idText chan, " ", topic]
+    entries' = clientFilterChannels st entries
 
     images = concatMap listItemImage entries'
 

--- a/src/Client/View/ChannelList.hs
+++ b/src/Client/View/ChannelList.hs
@@ -18,6 +18,7 @@ import           Client.State.Network
 import           Control.Lens
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
 import           Graphics.Vty.Attributes (defAttr)
 import           Irc.Identifier
 
@@ -43,12 +44,16 @@ channelListLines' cs width st
     pal = clientPalette st
 
     countImagePending = countImage <> text' (view palLabel pal) "..."
-    countImage = text' (view palLabel pal) "Channels: " <>
+    countImage = text' (view palLabel pal) "Channels (visible/total): " <>
+                 string defAttr (show (length entries')) <>
+                 char (view palLabel pal) '/' <>
                  string defAttr (show (length entries))
 
     entries = chanList^.clsItems
+    entries' = clientFilter st filterOn entries
+    filterOn (chan, _, topic) = LText.fromChunks [idText chan, " ", topic]
 
-    images = concatMap listItemImage entries
+    images = concatMap listItemImage entries'
 
     listItemImage :: (Identifier, Int, Text) -> [Image']
     listItemImage (chan, users, topic)

--- a/src/Client/View/ChannelList.hs
+++ b/src/Client/View/ChannelList.hs
@@ -1,0 +1,59 @@
+{-# Language OverloadedStrings #-}
+{-|
+Module      : Client.View.ChannelList
+Description : Line renderer for searchable channel lists
+Copyright   : (c) TheDaemoness, 2023
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+This module renders the lines used in the channel user list.
+-}
+module Client.View.ChannelList ( channelListLines ) where
+
+import           Client.Image.LineWrap (lineWrapPrefix)
+import           Client.Image.PackedImage
+import           Client.Image.Palette
+import           Client.State
+import           Client.State.Network
+import           Control.Lens
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Graphics.Vty.Attributes (defAttr)
+import           Irc.Identifier
+
+-- | Render the lines used by the @/list@ command in normal mode.
+channelListLines ::
+  Text        {- ^ network              -} ->
+  Int         {- ^ window width         -} ->
+  ClientState {- ^ client state         -} ->
+  [Image']
+channelListLines network width st =
+  case preview (clientConnection network) st of
+    Just cs -> channelListLines' cs width st
+    Nothing -> [text' (view palError pal) "No connection"]
+  where
+    pal = clientPalette st
+
+channelListLines' :: NetworkState -> Int -> ClientState -> [Image']
+channelListLines' cs width st
+  | (chanList^.clsDone) = countImage : images
+  | otherwise = countImagePending : images
+  where
+    chanList = cs^.csChannelList
+    pal = clientPalette st
+
+    countImagePending = countImage <> text' (view palLabel pal) "..."
+    countImage = text' (view palLabel pal) "Channels: " <>
+                 string defAttr (show (length entries))
+
+    entries = chanList^.clsItems
+
+    images = concatMap listItemImage entries
+
+    listItemImage :: (Identifier, Int, Text) -> [Image']
+    listItemImage (chan, users, topic)
+      | Text.null topic = [baseImage]
+      | otherwise = reverse $ lineWrapPrefix width (baseImage <> label " topic:") (text' defAttr topic)
+      where
+        baseImage = text' defAttr (idText chan) <> label " users: " <> text' defAttr (Text.pack . show $ users)
+        label = text' (view palLabel pal)

--- a/src/Client/View/UrlSelection.hs
+++ b/src/Client/View/UrlSelection.hs
@@ -40,12 +40,8 @@ urlSelectionView ::
   [Image']    {- ^ image lines         -}
 urlSelectionView w focus arg st
   = concat
-  $ zipWith (draw w hilites pal padding selected) [1..] (toListOf urled st)
+  $ zipWith (draw w hilites pal padding selected) [1..] (urlList st)
   where
-    urled = clientWindows . ix focus
-          . winMessages   . each
-          . folding matches
-
     focused = focus == view clientFocus st
 
     selected
@@ -59,11 +55,6 @@ urlSelectionView w focus arg st
     pal     = view configPalette cfg
 
     hilites = clientHighlightsFocus focus st
-
-
-matches :: WindowLine -> [(Maybe Identifier, Text)]
-matches wl = [ (views wlSummary summaryActor wl, url) | url <- views wlText urlMatches wl ]
-
 
 -- | Render one line of the url list
 draw ::


### PR DESCRIPTION
Adds a channel list view that appears when using `/list`.
glirc caches output from `LIST` and displays it using this view.
This list is searchable and works with `/url`.

Adds an argument to `/list` for searching by user count or forcibly reloading the channel list.
This may break some macros.

Moves some URL-related code to one place, so that `/url` support can be added to other views more-easily.