### PR TITLE
Add desktop notification support and more-granular noise controls

### DIFF
--- a/exec/Main.hs
+++ b/exec/Main.hs
@@ -86,4 +86,5 @@ buildVty :: IO Vty
 buildVty =
  do vty <- mkVty defaultConfig
     setMode (outputIface vty) BracketedPaste True
+    setMode (outputIface vty) Focus True
     pure vty

--- a/glirc.cabal
+++ b/glirc.cabal
@@ -89,6 +89,7 @@ library
     Client.Configuration
     Client.Configuration.Colors
     Client.Configuration.Macros
+    Client.Configuration.Notifications
     Client.Configuration.ServerSettings
     Client.Configuration.Sts
     Client.EventLoop

--- a/glirc.cabal
+++ b/glirc.cabal
@@ -183,6 +183,7 @@ library
     typed-process        ^>=0.2.10,
     psqueues             >=0.2.7  && <0.3,
     regex-tdfa           >=1.3.1  && <1.4,
+    semigroupoids        >=5.1    && <6.1,
     split                >=0.2    && <0.3,
     stm                  >=2.4    && <2.6,
     template-haskell     >=2.11   && <2.21,

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -231,7 +231,7 @@ windowCommands = CommandSection "Window management"
       (simpleToken ("hide|show" ++ concatMap ('|':) activityFilterStrings))
       "Set window property.\n\
       \\n\
-      \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bmute\^B / \^Bloud\^B / \^Blouder\^B\n\
+      \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bimponly\^B / \^Bloud\^B / \^Blouder\^B\n\
       \    Changes the importance of normal and important messages:\n\
       \      \^Bsilent\^B: Downgrades both to boring.\n\
       \\n\

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -228,7 +228,7 @@ windowCommands = CommandSection "Window management"
 
   , Command
       (pure "setwindow")
-      (simpleToken ("hide|show" ++ (concat $ map ('|':) activityFilterStrings)))
+      (simpleToken ("hide|show" ++ concatMap ('|':) activityFilterStrings))
       "Set window property.\n\
       \\n\
       \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bmute\^B / \^Bloud\^B / \^Blouder\^B\n\
@@ -293,7 +293,7 @@ tabSetWindow :: Bool {- ^ reversed -} -> ClientCommand String
 tabSetWindow isReversed st _ =
   simpleTabCompletion plainWordCompleteMode [] completions isReversed st
   where
-    completions = "hide":"show":(Text.pack <$> activityFilterStrings)
+    completions = "hide":"show": map Text.pack activityFilterStrings
 
 -- | Implementation of @/grep@
 cmdGrep :: ClientCommand String

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -233,6 +233,11 @@ windowCommands = CommandSection "Window management"
       \\n\
       \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bimponly\^B / \^Bloud\^B / \^Blouder\^B\n\
       \    Changes the importance of normal and important messages:\n\
+      \      \^Blouder\^B: Upgrades normal to important.\n\
+      \      \^Bloud\^B: Uses default values.\n\
+      \      \^Bimponly\^B: Downgrades normal to boring.\n\
+      \      \^Bquiet\^B: Downgrades important to normal.\n\
+      \      \^Bquieter\^B: Downgrades both one step.\n\
       \      \^Bsilent\^B: Downgrades both to boring.\n\
       \\n\
       \\^Bshow\^B / \^Bhide\^B\n\

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -18,7 +18,7 @@ import Client.State
 import Client.State.EditBox qualified as Edit
 import Client.State.Focus
 import Client.State.Network (csChannels)
-import Client.State.Window (windowClear, wlText, winMessages, winHidden, winSilent, winName)
+import Client.State.Window (windowClear, wlText, winMessages, winHidden, winActivityFilter, winName, ActivityFilter (..), activityFilterStrings, readActivityFilter)
 import Control.Applicative (liftA2)
 import Control.Exception (SomeException, Exception(displayException), try)
 import Control.Lens
@@ -228,11 +228,12 @@ windowCommands = CommandSection "Window management"
 
   , Command
       (pure "setwindow")
-      (simpleToken "hide|show|loud|silent")
+      (simpleToken ("hide|show" ++ (concat $ map ('|':) activityFilterStrings)))
       "Set window property.\n\
       \\n\
-      \\^Bloud\^B / \^Bsilent\^B\n\
-      \    Toggles if window activity appears in the status bar.\n\
+      \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bmute\^B / \^Bloud\^B / \^Blouder\^B\n\
+      \    Changes the importance of normal and important messages:\n\
+      \      \^Bsilent\^B: Downgrades both to boring.\n\
       \\n\
       \\^Bshow\^B / \^Bhide\^B\n\
       \    Toggles if window appears in window command shortcuts.\n"
@@ -284,17 +285,15 @@ cmdSetWindow st cmd =
   where
     mbFun =
       case cmd of
-        "show"   -> Just (set winHidden False)
-        "hide"   -> Just (set winName Nothing . set winHidden True)
-        "loud"   -> Just (set winSilent False)
-        "silent" -> Just (set winSilent True)
-        _        -> Nothing
+        "show"    -> Just (set winHidden False)
+        "hide"    -> Just (set winName Nothing . set winHidden True)
+        other     -> set winActivityFilter <$> readActivityFilter other
 
 tabSetWindow :: Bool {- ^ reversed -} -> ClientCommand String
 tabSetWindow isReversed st _ =
   simpleTabCompletion plainWordCompleteMode [] completions isReversed st
   where
-    completions = ["hide", "show", "loud", "silent"] :: [Text]
+    completions = "hide":"show":(Text.pack <$> activityFilterStrings)
 
 -- | Implementation of @/grep@
 cmdGrep :: ClientCommand String

--- a/src/Client/Configuration.hs
+++ b/src/Client/Configuration.hs
@@ -75,7 +75,7 @@ import Client.Commands.Interpolation (Macro)
 import Client.Commands.Recognizer (Recognizer)
 import Client.Configuration.Colors (attrSpec)
 import Client.Configuration.Macros (macroMapSpec)
-import Client.Configuration.Notifications (NotifyWith(..), notifyWithDefault)
+import Client.Configuration.Notifications (NotifyWith, notifySpec, notifyWithDefault)
 import Client.Configuration.ServerSettings
 import Client.EventLoop.Actions
 import Client.Image.Palette
@@ -486,15 +486,6 @@ urlOpenerSpec = simpleCase <!> complexCase
 
     argSpec = UrlArgUrl     <$  atomSpec "url"
           <!> UrlArgLiteral <$> stringSpec
-
-notifySpec :: ValueSpec NotifyWith
-notifySpec =
-  NotifyWithCustom []        <$ atomSpec "no"  <!>
-  notifyWithDefault          <$ atomSpec "yes" <!>
-  NotifyWithNotifySend       <$ atomSpec "notify-send" <!>
-  NotifyWithOsaScript        <$ atomSpec "osascript" <!>
-  NotifyWithTerminalNotifier <$ atomSpec "terminal-notifier" <!>
-  NotifyWithCustom . NonEmpty.toList <$> nonemptySpec stringSpec
 
 digraphSpec :: ValueSpec (Digraph, Text)
 digraphSpec =

--- a/src/Client/Configuration/Notifications.hs
+++ b/src/Client/Configuration/Notifications.hs
@@ -1,0 +1,40 @@
+{-# Language OverloadedStrings #-}
+{-|
+Module      : Client.Configuration.Notifications
+Description : Options for running commands to notify users
+Copyright   : (c) TheDaemoness, 2023
+License     : ISC
+Maintainer  : emertens@gmail.com
+-}
+module Client.Configuration.Notifications ( NotifyWith(..), notifyCmd, notifyWithDefault ) where
+
+import qualified Data.Text.Lazy as LText
+import           System.Process.Typed (ProcessConfig, proc, setEnv)
+import           System.Info (os)
+
+data NotifyWith
+  = NotifyWithCustom [String]
+  | NotifyWithNotifySend
+  | NotifyWithOsaScript
+  | NotifyWithTerminalNotifier
+  deriving Show
+
+notifyCmd :: NotifyWith -> Maybe ((LText.Text, LText.Text) -> ProcessConfig () () ())
+notifyCmd (NotifyWithCustom (cmd:args)) = Just $ \(header, body) ->
+  proc cmd (args ++ [LText.unpack header, LText.unpack body])
+notifyCmd NotifyWithNotifySend = Just $ \(header, body) ->
+  proc "notify-send" ["-a", "glirc", LText.unpack header, LText.unpack body]
+notifyCmd NotifyWithOsaScript = Just $ \(header, body) ->
+  setEnv [("_GLIRC_NOTIF_HEADER", LText.unpack header), ("_GLIRC_NOTIF_BODY", LText.unpack body)] $
+  proc "osascript" ["-e", script]
+  where
+    script = "display notification system attribute \"_GLIRC_NOTIF_BODY\" with title \"glirc\" with subtitle system attribute \"_GLIRC_NOTIF_HEADER\""
+notifyCmd NotifyWithTerminalNotifier = Just $ \(header, body) ->
+  proc "terminal-notifier" ["-title", "glirc", "-subtitle", LText.unpack header, "-message", LText.unpack body]
+notifyCmd _ = Nothing
+
+notifyWithDefault :: NotifyWith
+notifyWithDefault = case os of
+  "darwin" -> NotifyWithOsaScript
+  "linux"  -> NotifyWithNotifySend
+  _        -> NotifyWithCustom []

--- a/src/Client/Configuration/Notifications.hs
+++ b/src/Client/Configuration/Notifications.hs
@@ -6,11 +6,13 @@ Copyright   : (c) TheDaemoness, 2023
 License     : ISC
 Maintainer  : emertens@gmail.com
 -}
-module Client.Configuration.Notifications ( NotifyWith(..), notifyCmd, notifyWithDefault ) where
+module Client.Configuration.Notifications ( NotifyWith, notifyCmd, notifySpec, notifyWithDefault ) where
 
+import           Config.Schema (ValueSpec, atomSpec, nonemptySpec, stringSpec, (<!>))
 import qualified Data.Text.Lazy as LText
 import           System.Process.Typed (ProcessConfig, proc, setEnv)
 import           System.Info (os)
+import qualified Data.List.NonEmpty as NonEmpty
 
 data NotifyWith
   = NotifyWithCustom [String]
@@ -38,3 +40,12 @@ notifyWithDefault = case os of
   "darwin" -> NotifyWithOsaScript
   "linux"  -> NotifyWithNotifySend
   _        -> NotifyWithCustom []
+
+notifySpec :: ValueSpec NotifyWith
+notifySpec =
+  NotifyWithCustom []        <$ atomSpec "no"  <!>
+  notifyWithDefault          <$ atomSpec "yes" <!>
+  NotifyWithNotifySend       <$ atomSpec "notify-send" <!>
+  NotifyWithOsaScript        <$ atomSpec "osascript" <!>
+  NotifyWithTerminalNotifier <$ atomSpec "terminal-notifier" <!>
+  NotifyWithCustom . NonEmpty.toList <$> nonemptySpec stringSpec

--- a/src/Client/Configuration/Notifications.hs
+++ b/src/Client/Configuration/Notifications.hs
@@ -32,7 +32,7 @@ notifyCmd NotifyWithOsaScript = Just $ \(header, body) ->
   where
     script = "display notification (system attribute \"_GLIRC_NOTIF_BODY\") with title \"glirc\" subtitle (system attribute \"_GLIRC_NOTIF_HEADER\")"
 notifyCmd NotifyWithTerminalNotifier = Just $ \(header, body) ->
-  proc "terminal-notifier" ["-title", "glirc", "-subtitle", LText.unpack header, "-message", LText.unpack body]
+  proc "terminal-notifier" ["-title", "glirc", "-subtitle", LText.unpack header, "-message", "\\" <> LText.unpack body]
 notifyCmd _ = Nothing
 
 notifyWithDefault :: NotifyWith

--- a/src/Client/Configuration/Notifications.hs
+++ b/src/Client/Configuration/Notifications.hs
@@ -6,7 +6,7 @@ Copyright   : (c) TheDaemoness, 2023
 License     : ISC
 Maintainer  : emertens@gmail.com
 -}
-module Client.Configuration.Notifications ( NotifyWith, notifyCmd, notifySpec, notifyWithDefault ) where
+module Client.Configuration.Notifications ( NotifyWith(..), notifyCmd, notifySpec, notifyWithDefault ) where
 
 import           Config.Schema (ValueSpec, atomSpec, nonemptySpec, stringSpec, (<!>))
 import qualified Data.Text.Lazy as LText

--- a/src/Client/Configuration/Notifications.hs
+++ b/src/Client/Configuration/Notifications.hs
@@ -30,7 +30,7 @@ notifyCmd NotifyWithOsaScript = Just $ \(header, body) ->
   setEnv [("_GLIRC_NOTIF_HEADER", LText.unpack header), ("_GLIRC_NOTIF_BODY", LText.unpack body)] $
   proc "osascript" ["-e", script]
   where
-    script = "display notification system attribute \"_GLIRC_NOTIF_BODY\" with title \"glirc\" with subtitle system attribute \"_GLIRC_NOTIF_HEADER\""
+    script = "display notification (system attribute \"_GLIRC_NOTIF_BODY\") with title \"glirc\" subtitle (system attribute \"_GLIRC_NOTIF_HEADER\")"
 notifyCmd NotifyWithTerminalNotifier = Just $ \(header, body) ->
   proc "terminal-notifier" ["-title", "glirc", "-subtitle", LText.unpack header, "-message", LText.unpack body]
 notifyCmd _ = Nothing

--- a/src/Client/Configuration/ServerSettings.hs
+++ b/src/Client/Configuration/ServerSettings.hs
@@ -92,6 +92,7 @@ import Client.Commands.Interpolation (ExpansionChunk)
 import Client.Commands.WordCompletion
 import Client.Configuration.Macros (macroCommandSpec)
 import Client.State.Focus ( Focus (NetworkFocus, ChannelFocus) )
+import Client.State.Window (ActivityFilter (..))
 import Config.Schema.Spec
 import Control.Exception (Exception, displayException, throwIO, try)
 import Control.Lens
@@ -106,6 +107,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Endo(Endo))
+import Data.Semigroup.Foldable (asum1)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
@@ -117,7 +119,6 @@ import System.Exit qualified as Exit
 import System.Process.Typed qualified as Process
 import Text.Regex.TDFA (Regex, RegexOptions(defaultCompOpt), ExecOption(ExecOption, captureGroups))
 import Text.Regex.TDFA.Text (compile)
-import Client.State.Window (ActivityFilter (..))
 
 -- | Static server-level settings
 data ServerSettings = ServerSettings
@@ -420,9 +421,9 @@ tlsModeSpec =
 
 -- TODO: May be nice to be able to do this for all Show Enums.
 activitySpec :: ValueSpec ActivityFilter
-activitySpec = foldl1 (<!>) $ map mkSpec [(toEnum 0)..]
+activitySpec = asum1 (NonEmpty.fromList (map mkSpec [(toEnum 0)..]))
   where
-    mkSpec a = a <$ atomSpec (Text.pack $ show a)
+    mkSpec a = a <$ atomSpec (Text.pack (show a))
 
 tlsVerifySpec :: ValueSpec TlsVerify
 tlsVerifySpec =

--- a/src/Client/Configuration/ServerSettings.hs
+++ b/src/Client/Configuration/ServerSettings.hs
@@ -181,7 +181,6 @@ data SaslMechanism
 data WindowHint = WindowHint
   { windowHintName     :: Maybe Char
   , windowHintHideMeta :: Maybe Bool
-  , windowHintSilent   :: Maybe Bool
   , windowHintHidden   :: Maybe Bool
   , windowHintActivity :: Maybe ActivityFilter
   } deriving Show
@@ -401,7 +400,6 @@ windowHintsSpec = Map.fromList <$> listSpec entrySpec
            windowHintHidden   <- optSection' "hidden"    yesOrNoSpec "hide from statusbar"
            windowHintHideMeta <- optSection' "hide-meta" yesOrNoSpec "hide metadata by default"
            windowHintActivity <- optSection' "activity"  activitySpec "activity indicators"
-           windowHintSilent   <- optSection' "silent"    yesOrNoSpec "[deprecated] hide activity counters"
            pure (focus, WindowHint{..})
 
     focusSpec =

--- a/src/Client/EventLoop.hs
+++ b/src/Client/EventLoop.hs
@@ -19,7 +19,8 @@ module Client.EventLoop
 
 import Client.CApi (ThreadEntry, popTimer)
 import Client.Commands (CommandResult(..), execute, executeUserCommand, tabCompletion)
-import Client.Configuration (configJumpModifier, configKeyMap, configWindowNames, configDigraphs)
+import Client.Configuration (configJumpModifier, configKeyMap, configWindowNames, configDigraphs, configNotifications)
+import Client.Configuration.Notifications (notifyCmd)
 import Client.Configuration.ServerSettings ( ssReconnectAttempts )
 import Client.EventLoop.Actions (keyToAction, Action(..))
 import Client.EventLoop.Errors (exceptionToLines)
@@ -52,7 +53,6 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.Encoding.Error qualified as Text
-import qualified Data.Text.Lazy as LText
 import Data.Time
 import Data.Time.Format.ISO8601 (formatParseM, iso8601Format)
 import Data.Traversable (for)
@@ -64,7 +64,7 @@ import Irc.Codes (pattern RPL_STARTTLS)
 import Irc.Message (IrcMsg(Reply, Notice), cookIrcMsg, msgTarget)
 import Irc.RawIrcMsg (RawIrcMsg, TagEntry(..), asUtf8, msgTags, parseRawIrcMsg)
 import LensUtils (setStrict)
-import System.Process.Typed (proc, startProcess, setStdin, setStdout, setStderr, nullStream)
+import System.Process.Typed (startProcess, setStdin, setStdout, setStderr, nullStream)
 
 
 -- | Sum of the five possible event types the event loop handles
@@ -180,18 +180,15 @@ processLogEntries =
   traverse_ writeLogLine . reverse . view clientLogQueue
 
 processNotifications :: ClientState -> IO ()
-processNotifications st
-  | view clientUiFocused st = return () -- We're focused; do nothing.
-  | otherwise = foldr (>>) (return ()) $ map spawn $ view clientNotifications st
+processNotifications st = case notifyCmd (view (clientConfig . configNotifications) st) of
+  Just cmd | not $ view clientUiFocused st -> foldr (>>) (return ()) $ map (spawn cmd) $ view clientNotifications st
+  _ -> return ()
   where
-    baseProcCfg (focus, body) =
-      proc "notify-send" ["-a", "glirc", LText.unpack focus, LText.unpack body] -- FIXME: Hardcoded!
     -- TODO: May be a nicer way to handle notification failure than just silently squashing the exception
     handleException :: SomeException -> IO ()
     handleException _ = return ()
-    spawn :: (LText.Text, LText.Text) -> IO ()
-    spawn pair = do
-      let procCfg = setStdin nullStream . setStdout nullStream . setStderr nullStream $ baseProcCfg pair
+    spawn cmd pair = do
+      let procCfg = setStdin nullStream . setStdout nullStream . setStderr nullStream $ cmd pair
       -- Maybe find a nicer way to get an error out of here.
       catch (startProcess procCfg >> return ()) handleException
 

--- a/src/Client/Image/StatusLine.hs
+++ b/src/Client/Image/StatusLine.hs
@@ -224,7 +224,6 @@ activitySummary st
       let name = case view winName w of
                    Nothing -> '?'
                    Just i -> i in
-      if view winSilent w then rest else
       case view winMention w of
         WLImportant -> Vty.char (view palMention  pal) name : rest
         WLNormal    -> Vty.char (view palActivity pal) name : rest
@@ -241,7 +240,7 @@ activityBarImages st
 
   where
     baraux (focus,w)
-      | view winSilent w = Nothing
+      | view winActivityFilter w == AFSilent = Nothing
       | n == 0 = Nothing -- todo: make configurable
       | otherwise = Just
                   $ unpackImage bar Vty.<|>

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -617,9 +617,7 @@ recordWindowLine' ::
 recordWindowLine' create focus wl st = st2
   where
     hints = clientWindowHint focus st
-    winActivity
-      | fromMaybe False (windowHintSilent =<< hints) = AFSilent
-      | otherwise = fromMaybe AFLoud (windowHintActivity =<< hints)
+    winActivity = fromMaybe AFLoud (windowHintActivity =<< hints)
 
     freshWindow = emptyWindow
       { _winName'    = clientNextWindowName hints st

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -232,6 +232,16 @@ data ExtensionState = ExtensionState
   , _esStablePtr :: StablePtr (MVar ParkState) -- ^ 'StablePtr' used with 'clientPark'
   }
 
+data NotifCfg = NotifCfgOff
+  | NotifCfgNotifySend
+  | NotifCfgOsaScript
+  | NotifCfgTerminalNotifier
+  | NotifCfgCustom [String] 
+  deriving Show
+
+notificationsCmd :: NotifCfg -> (LText.Text, LText.Text) -> [String]
+notificationsCmd NotifCfgOff _ = []
+
 -- | ID of active extension and stored client state
 type ParkState = (Int,ClientState)
 

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -665,9 +665,13 @@ addNotify :: Bool -> Focus -> WindowLine -> ClientState -> ClientState
 addNotify False _     _  st = st
 addNotify True  focus wl st
   | focus == view clientFocus st && view clientUiFocused st = st
-  | otherwise = over clientNotifications (cons (focusText focus, body)) st
+  | otherwise = addBell $ over clientNotifications (cons (focusText focus, bodyText)) st
   where
-    body = imageText (view wlPrefix wl) <> " " <> imageText (view wlImage wl)
+    addBell st'
+      | not (view clientBell st')
+      , view (clientConfig . configBellOnMention) st' = set clientBell True st'
+      | otherwise = st'
+    bodyText = imageText (view wlPrefix wl) <> " " <> imageText (view wlImage wl)
     focusText Unfocused = "Application Notice"
     focusText (NetworkFocus net) = LText.fromChunks ["Notice from ", net]
     focusText (ChannelFocus net chan) = LText.fromChunks ["Activity on ", net, ":", idText chan]

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -232,16 +232,6 @@ data ExtensionState = ExtensionState
   , _esStablePtr :: StablePtr (MVar ParkState) -- ^ 'StablePtr' used with 'clientPark'
   }
 
-data NotifCfg = NotifCfgOff
-  | NotifCfgNotifySend
-  | NotifCfgOsaScript
-  | NotifCfgTerminalNotifier
-  | NotifCfgCustom [String] 
-  deriving Show
-
-notificationsCmd :: NotifCfg -> (LText.Text, LText.Text) -> [String]
-notificationsCmd NotifCfgOff _ = []
-
 -- | ID of active extension and stored client state
 type ParkState = (Int,ClientState)
 

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -300,7 +300,7 @@ withClientState cfgPath cfg k =
         , _clientEditLock          = False
         , _clientActivityBar       = view configActivityBar cfg
         , _clientShowPing          = view configShowPing cfg
-        , _clientNotifications            = []
+        , _clientNotifications     = []
         , _clientBell              = False
         , _clientUiFocused         = True
         , _clientExtensions        = exts
@@ -667,7 +667,7 @@ addNotify True  focus wl st
   | focus == view clientFocus st && view clientUiFocused st = st
   | otherwise = over clientNotifications (cons (focusText focus, body)) st
   where
-    body = LText.intercalate " " [imageText $ view wlPrefix wl, imageText $ view wlImage wl]
+    body = imageText (view wlPrefix wl) <> " " <> imageText (view wlImage wl)
     focusText Unfocused = "Application Notice"
     focusText (NetworkFocus net) = LText.fromChunks ["Notice from ", net]
     focusText (ChannelFocus net chan) = LText.fromChunks ["Activity on ", net, ":", idText chan]

--- a/src/Client/State/Window.hs
+++ b/src/Client/State/Window.hs
@@ -23,7 +23,7 @@ module Client.State.Window
   , winMarker
   , winHideMeta
   , winHidden
-  , winSilent
+  , winActivityFilter
 
   -- * Window lines
   , WindowLines(..)
@@ -37,7 +37,11 @@ module Client.State.Window
   , wlTimestamp
 
   -- * Window line importance
+  , ActivityFilter(..)
   , WindowLineImportance(..)
+  , activityFilterStrings
+  , applyActivityFilter
+  , readActivityFilter
 
   -- * Window operations
   , emptyWindow
@@ -62,6 +66,7 @@ import Data.Bits ((.|.), (.&.), shiftL, shiftR)
 import Data.Text.Lazy (Text)
 import Data.Time
 import Data.Word (Word64)
+import Data.List (elemIndex)
 
 -- | A single message to be displayed in a window.
 -- The normal message line consists of the image prefix
@@ -94,7 +99,7 @@ data Window = Window
   , _winMention  :: !WindowLineImportance -- ^ Indicates an important event is unread
   , _winHideMeta :: !Bool          -- ^ Hide metadata messages
   , _winHidden   :: !Bool          -- ^ Remove from jump rotation
-  , _winSilent   :: !Bool          -- ^ Ignore activity
+  , _winActivityFilter :: !ActivityFilter -- ^ Filters for activity
   }
 
 data ActivityLevel = NoActivity | NormalActivity | HighActivity
@@ -106,6 +111,33 @@ data WindowLineImportance
   | WLNormal -- ^ Increment unread count
   | WLImportant -- ^ Increment unread count and set important flag
   deriving (Eq, Ord, Show, Read)
+
+data ActivityFilter
+  = AFSilent
+  | AFQuieter
+  | AFQuiet
+  | AFImpOnly
+  | AFLoud
+  | AFLouder
+  deriving (Eq, Ord, Enum)
+
+activityFilterStrings :: [String]
+activityFilterStrings = ["silent", "quieter", "quiet", "imponly", "loud", "louder"]
+
+applyActivityFilter :: ActivityFilter -> WindowLineImportance -> WindowLineImportance
+applyActivityFilter AFSilent  _           = WLBoring
+applyActivityFilter AFQuieter WLNormal    = WLBoring
+applyActivityFilter AFQuieter WLImportant = WLNormal
+applyActivityFilter AFImpOnly WLNormal    = WLBoring
+applyActivityFilter AFQuiet   WLImportant = WLNormal
+applyActivityFilter AFLouder  WLNormal    = WLImportant
+applyActivityFilter _ etc = etc
+
+instance Show ActivityFilter where
+  show af = activityFilterStrings !! fromEnum af
+
+readActivityFilter :: String -> Maybe ActivityFilter
+readActivityFilter s = toEnum <$> elemIndex s activityFilterStrings
 
 makeLenses ''Window
 makeLenses ''WindowLine
@@ -127,7 +159,7 @@ emptyWindow = Window
   , _winMention  = WLBoring
   , _winHideMeta = False
   , _winHidden   = False
-  , _winSilent   = False
+  , _winActivityFilter   = AFLoud
   }
 
 windowClear :: Window -> Window
@@ -146,12 +178,14 @@ addToWindow !msg !win = win
     { _winMessages = msg :- view winMessages win
     , _winTotal    = view winTotal win + 1
     , _winMarker   = (+1) <$!> view winMarker win
-    , _winUnread   = if view wlImportance msg == WLBoring
+    , _winUnread   = if msgImportance == WLBoring
                      then view winUnread win
                      else view winUnread win + 1
-    , _winMention  = max (view winMention win) (view wlImportance msg)
+    , _winMention  = max (view winMention win) msgImportance
     , _winHideMeta = view winHideMeta win
     }
+    where
+      msgImportance = applyActivityFilter (view winActivityFilter win) (view wlImportance msg)
 
 -- | Update the window clearing the unread count and important flag.
 windowSeen :: Window -> Window

--- a/src/Client/View/Windows.hs
+++ b/src/Client/View/Windows.hs
@@ -98,7 +98,9 @@ renderedWindowInfo :: Palette -> Window -> Image'
 renderedWindowInfo pal win =
   string (view newMsgAttrLens pal) (views winUnread show win) <> "/" <>
   string (view palActivity    pal) (views winTotal  show win) <>
-  (if view winSilent win then text' (view palMeta pal) " silent" else mempty)
+  case view winActivityFilter win of
+    AFLoud -> mempty
+    other -> string (view palMeta pal) (' ':show other)
   where
     newMsgAttrLens =
       case view winMention win of


### PR DESCRIPTION
Closes #107.

BREAKING CHANGE: This replaces the "silent" window hint with "activity" (let me know if there's a better name you'd prefer) . To migrate, replace all window hint instances of`silent: yes` with `activity: silent`, and `slient: no` with `activity: loud`.