### PR TITLE
Improve palette options and usage

### DIFF
--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -18,7 +18,7 @@ import Client.State
 import Client.State.EditBox qualified as Edit
 import Client.State.Focus
 import Client.State.Network (csChannels)
-import Client.State.Window (windowClear, wlText, winMessages, winHidden, winActivityFilter, winName, ActivityFilter (..), activityFilterStrings, readActivityFilter)
+import Client.State.Window (windowClear, wlText, winMessages, winHidden, winActivityFilter, winName, activityFilterStrings, readActivityFilter)
 import Control.Applicative (liftA2)
 import Control.Exception (SomeException, Exception(displayException), try)
 import Control.Lens

--- a/src/Client/Configuration/ServerSettings.hs
+++ b/src/Client/Configuration/ServerSettings.hs
@@ -612,5 +612,6 @@ netPaletteSpec =
                     "Overrides for the styles used for specific snomask letters."
      pure NetworkPalette{..}
   where
-    colorMapSpec = HashMap.fromList . concatMap transpose <$> assocSpec attrSpec
-      where transpose (modes, style) = [(mode, style) | mode <- Text.unpack modes, isLetter mode]
+    colorMapSpec = HashMap.fromList . concatMap expand <$> assocSpec attrSpec
+      where
+        expand (modes, style) = [(mode, style) | mode <- Text.unpack modes, isLetter mode]

--- a/src/Client/Image/Message.hs
+++ b/src/Client/Image/Message.hs
@@ -25,6 +25,7 @@ module Client.Image.Message
   , nickPad
   , timeImage
   , drawWindowLine
+  , modesImage
 
   , parseIrcTextWithNicks
   , Highlight(..)
@@ -39,12 +40,13 @@ import Client.Message
 import Client.State.Window (unpackTimeOfDay, wlImage, wlPrefix, wlTimestamp, WindowLine)
 import Client.UserHost ( uhAccount, UserAndHost )
 import Control.Applicative ((<|>))
-import Control.Lens (view, (^?), filtered, folded, views, Ixed(ix))
+import Control.Lens (view, (^?), filtered, folded, views, Ixed(ix), At (at))
 import Data.Char (ord, chr, isControl)
 import Data.Hashable (hash)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HashMap
 import Data.List (intercalate, intersperse)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time (UTCTime, ZonedTime, TimeOfDay, formatTime, defaultTimeLocale, parseTimeM)
@@ -336,9 +338,14 @@ ircLineImage !rp body =
       separatedParams pal (view msgParams irc)
     Cap cmd           -> ctxt (capCmdText cmd)
 
-    Mode _ _ params ->
+    Mode _ chan (modes:params) ->
       "set mode: " <>
+      modesImage (view palModes pal) (modesPaletteFor chan pal) (Text.unpack modes) <>
+      " " <>
       ircWords pal params
+
+    Mode _ _ [] ->
+      "changed no modes"
 
     Invite _ tgt chan ->
       "invited " <>
@@ -377,13 +384,13 @@ fullIrcLineImage !rp body =
   in
   case body of
     Nick old new ->
-      string quietAttr "nick " <>
+      string (view palUsrChg pal) "nick " <>
       who old <>
       " is now known as " <>
       coloredIdentifier pal NormalIdentifier hilites new
 
     Join nick _chan acct gecos ->
-      string quietAttr "join " <>
+      string (view palJoin pal) "join " <>
       plainWho (srcUser nick) <>
       accountPart <> gecosPart
       where
@@ -396,21 +403,21 @@ fullIrcLineImage !rp body =
           | otherwise       = text' quietAttr (" [" <> cleanText gecos <> "]")
 
     Part nick _chan mbreason ->
-      string quietAttr "part " <>
+      string (view palPart pal) "part " <>
       who nick <>
       foldMap (\reason -> string quietAttr " (" <>
                           parseIrcText pal reason <>
                           string quietAttr ")") mbreason
 
     Quit nick mbreason ->
-      string quietAttr "quit "   <>
+      string (view palPart pal) "quit "   <>
       who nick <>
       foldMap (\reason -> string quietAttr " (" <>
                           parseIrcText pal reason <>
                           string quietAttr ")") mbreason
 
     Kick kicker _channel kickee reason ->
-      string quietAttr "kick " <>
+      string (view palPart pal) "kick " <>
       who kicker <>
       " kicked " <>
       coloredIdentifier pal NormalIdentifier hilites kickee <>
@@ -418,7 +425,7 @@ fullIrcLineImage !rp body =
       parseIrcText pal reason
 
     Kill killer killee reason ->
-      string quietAttr "kill " <>
+      string (view palPart pal) "kill " <>
       who killer <>
       " killed " <>
       coloredIdentifier pal NormalIdentifier hilites killee <>
@@ -500,32 +507,38 @@ fullIrcLineImage !rp body =
       ": " <>
       ctxt (capCmdText cmd)
 
-    Mode nick _chan params ->
-      string quietAttr "mode " <>
+    Mode nick chan (modes:params) ->
+      string (view palModes pal) "mode " <>
       who nick <> " set mode: " <>
+      modesImage (view palModes pal) (modesPaletteFor chan pal) (Text.unpack modes) <>
+      " " <>
       ircWords pal params
+
+    Mode nick _ [] ->
+      string (view palModes pal) "mode " <>
+      who nick <> " changed no modes"
 
     Authenticate{} -> "AUTHENTICATE ***"
     BatchStart{}   -> "BATCH +"
     BatchEnd{}     -> "BATCH -"
 
     Account src acct ->
-      string quietAttr "acct " <>
+      string (view palUsrChg pal) "acct " <>
       who src <> ": " <>
       if Text.null acct then "*" else ctxt acct
 
     Chghost user newuser newhost ->
-      string quietAttr "chng " <>
+      string (view palUsrChg pal) "chng " <>
       who user <> ": " <>
       ctxt newuser <> " " <> ctxt newhost
 
     Away user (Just txt) ->
-      string quietAttr "away " <>
+      string (view palAway pal) "away " <>
       who user <> ": " <>
       parseIrcTextWithNicks pal hilites False txt
 
     Away user Nothing ->
-      string quietAttr "back " <>
+      string (view palUsrChg pal) "back " <>
       who user
 
 
@@ -1186,26 +1199,29 @@ highlightNicks palette hilites txt = foldMap highlight1 txtParts
 
 -- | Returns image and identifier to be used when collapsing metadata
 -- messages.
-metadataImg :: IrcSummary -> Maybe (Image', Identifier, Maybe Identifier)
-metadataImg msg =
+metadataImg :: Palette -> IrcSummary -> Maybe (Image', Identifier, Maybe Identifier)
+metadataImg pal msg =
   case msg of
-    QuitSummary who _     -> Just (char (withForeColor defAttr red   ) 'x', who, Nothing)
-    PartSummary who       -> Just (char (withForeColor defAttr red   ) '-', who, Nothing)
-    JoinSummary who       -> Just (char (withForeColor defAttr green ) '+', who, Nothing)
-    CtcpSummary who       -> Just (char (withForeColor defAttr white ) 'C', who, Nothing)
-    NickSummary old new   -> Just (char (withForeColor defAttr yellow) '>', old, Just new)
-    ChngSummary who       -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
-    AcctSummary who       -> Just (char (withForeColor defAttr blue  ) '*', who, Nothing)
-    AwaySummary who True  -> Just (char (withForeColor defAttr yellow) 'a', who, Nothing)
-    AwaySummary who False -> Just (char (withForeColor defAttr green ) 'b', who, Nothing)
+    QuitSummary who _     -> Just (char (view palPart pal)   'x', who, Nothing)
+    PartSummary who       -> Just (char (view palPart pal)   '-', who, Nothing)
+    JoinSummary who       -> Just (char (view palJoin pal)   '+', who, Nothing)
+    CtcpSummary who       -> Just (char (view palIgnore pal) 'C', who, Nothing)
+    NickSummary old new   -> Just (char (view palUsrChg pal) '>', old, Just new)
+    ChngSummary who       -> Just (char (view palUsrChg pal) '@', who, Nothing)
+    AcctSummary who       -> Just (char (view palUsrChg pal) '*', who, Nothing)
+    AwaySummary who True  -> Just (char (view palAway pal)   'a', who, Nothing)
+    AwaySummary who False -> Just (char (view palUsrChg pal) 'b', who, Nothing)
     _                     -> Nothing
 
-
-
 -- | Image used when treating ignored chat messages as metadata
-ignoreImage :: Image'
-ignoreImage = char (withForeColor defAttr yellow) 'I'
+ignoreImage :: Palette -> Image'
+ignoreImage pal = char (view palIgnore pal) 'I'
 
+modesImage :: Attr -> HashMap Char Attr -> String -> Image'
+modesImage def pal modes = foldMap modeImage modes
+  where
+    modeImage m =
+      char (fromMaybe def (view (at m) pal)) m
 
 -- | Render the normal view of a chat message line padded and wrapped.
 drawWindowLine ::

--- a/src/Client/Image/StatusLine.hs
+++ b/src/Client/Image/StatusLine.hs
@@ -300,13 +300,14 @@ myNickImage st =
     Unfocused                 -> Vty.emptyImage
   where
     pal = clientPalette st
+    netpal = clientNetworkPalette st
     nickPart network =
       case preview (clientConnection network) st of
         Nothing -> Vty.emptyImage
         Just cs -> Vty.text' attr (cleanText (idText nick))
            Vty.<|> parens defAttr
                      (unpackImage $
-                      modesImage (view palModes pal) (view palUModes pal) ('+':view csModes cs) <>
+                      modesImage (view palModes pal) (view palUModes netpal) ('+':view csModes cs) <>
                       snomaskImage)
           where
             attr
@@ -318,7 +319,7 @@ myNickImage st =
             snomaskImage
               | null (view csSnomask cs) = ""
               | otherwise                = " " <>
-                modesImage (view palModes pal) (view palSnomask pal) ('+':view csSnomask cs)
+                modesImage (view palModes pal) (view palSnomask netpal) ('+':view csSnomask cs)
 
 subfocusImage :: Subfocus -> ClientState -> Image'
 subfocusImage subfocus st = foldMap infoBubble (viewSubfocusLabel pal subfocus)
@@ -340,8 +341,10 @@ parens attr i = Vty.char attr '(' Vty.<|> i Vty.<|> Vty.char attr ')'
 
 viewFocusLabel :: ClientState -> Focus -> Image'
 viewFocusLabel st focus =
-  let !pal = clientPalette st in
-  case focus of
+  let
+    !pal = clientPalette st
+    netpal = clientNetworkPalette st
+  in case focus of
     Unfocused ->
       char (view palError pal) '*'
     NetworkFocus network ->
@@ -363,7 +366,7 @@ viewFocusLabel st focus =
 
                , case preview (csChannels . ix channel . chanModes) cs of
                     Just modeMap | not (null modeMap) ->
-                        " " <> modesImage (view palModes pal) (view palCModes pal) ('+':Map.keys modeMap)
+                        " " <> modesImage (view palModes pal) (view palCModes netpal) ('+':Map.keys modeMap)
                     _ -> mempty
                )
 

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -363,6 +363,7 @@ recordChannelMessage' create network channel msg st
       , rendPalette     = clientPalette st
       , rendAccounts    = accounts
       , rendNetPalette  = clientNetworkPalette st
+      , rendChanTypes   = "#&!+" -- TODO: Don't hardcode this, use CHANTYPES ISUPPORT.
       }
 
     -- on failure returns mempty/""

--- a/src/Client/State.hs
+++ b/src/Client/State.hs
@@ -57,6 +57,7 @@ module Client.State
   , clientIsFiltered
   , clientFilter
   , clientFilterChannels
+  , clientNetworkPalette
   , buildMatcher
   , clientToggleHideMeta
   , channelUserList
@@ -166,7 +167,6 @@ import           RtsStats (Stats)
 import qualified System.Random as Random
 import           Text.Regex.TDFA
 import           Text.Regex.TDFA.String (compile)
-
 
 -- | All state information for the IRC client
 data ClientState = ClientState
@@ -362,6 +362,7 @@ recordChannelMessage' create network channel msg st
       , rendHighlights  = highlights
       , rendPalette     = clientPalette st
       , rendAccounts    = accounts
+      , rendNetPalette  = clientNetworkPalette st
       }
 
     -- on failure returns mempty/""
@@ -1218,3 +1219,9 @@ clientAutoconnects st =
 clientToggleHideMeta :: ClientState -> ClientState
 clientToggleHideMeta st =
   overStrict (clientWindows . ix (view clientFocus st) . winHideMeta) not st
+
+-- | Generates the NetworkPalette for the current focus.
+clientNetworkPalette :: ClientState -> NetworkPalette
+clientNetworkPalette st = case focusNetwork (view clientFocus st) of
+  Just net -> configNetworkPalette net (view clientConfig st)
+  Nothing  -> defaultNetworkPalette

--- a/src/Client/View/Mentions.hs
+++ b/src/Client/View/Mentions.hs
@@ -84,7 +84,7 @@ windowEntries filt palette w padAmt detailed focus win =
   [ MentionLine
       { mlTimestamp  = views wlTimestamp unpackUTCTime l
       , mlFocus      = focus
-      , mlImage      = case metadataImg (view wlSummary l) of
+      , mlImage      = case metadataImg palette (view wlSummary l) of
                          _ | detailed     -> [view wlFullImage l]
                          Just (img, _, _) -> [img]
                          Nothing          -> drawWindowLine palette w padAmt l

--- a/src/Client/View/Messages.hs
+++ b/src/Client/View/Messages.hs
@@ -28,7 +28,6 @@ import           Client.State.Window
 import           Control.Lens
 import           Control.Monad
 import           Data.List
-import           Graphics.Vty.Attributes
 import           Irc.Identifier
 import           Irc.Message
 import           Irc.UserInfo
@@ -176,8 +175,10 @@ metadataWindowLine ::
         {- ^ Image, incoming identifier, outgoing identifier if changed -}
 metadataWindowLine st wl =
   case view wlSummary wl of
-    ChatSummary who -> (ignoreImage, userNick who, Nothing) <$ guard (identIgnored who st)
-    summary         -> metadataImg summary
+    ChatSummary who -> (ignoreImage pal, userNick who, Nothing) <$ guard (identIgnored who st)
+    summary         -> metadataImg (clientPalette st) summary
+  where
+    pal = clientPalette st
 
 bulkMetadata ::
   ClientState ->
@@ -187,8 +188,7 @@ bulkMetadata st wls
   | (quits, wls') <- span isMassQuit wls
   , let n = length quits
   , n > 10
-  = Just (string (view palMeta pal) ("(split:" <> show n <> ")") <>
-          char (withForeColor defAttr red) 'X', wls')
+  = Just (string (view palPart pal) ("(split:" <> show n <> ")x"), wls')
   where
     pal = clientPalette st
 

--- a/src/Client/View/UrlSelection.hs
+++ b/src/Client/View/UrlSelection.hs
@@ -19,10 +19,8 @@ import           Client.Image.Message
 import           Client.Image.PackedImage
 import           Client.Image.Palette
 import           Client.Image.LineWrap
-import           Client.Message
 import           Client.State
 import           Client.State.Focus
-import           Client.State.Window
 import           Control.Lens
 import           Data.HashMap.Strict (HashMap)
 import           Data.Text (Text)

--- a/src/Client/View/Windows.hs
+++ b/src/Client/View/Windows.hs
@@ -13,6 +13,7 @@ module Client.View.Windows
   ( windowsImages
   ) where
 
+import           Client.Image.Message (coloredIdentifier, IdentifierColorMode (NormalIdentifier))
 import           Client.Image.PackedImage
 import           Client.Image.Palette
 import           Client.State
@@ -20,11 +21,11 @@ import           Client.State.Focus
 import           Client.State.Window
 import           Client.State.Network
 import           Control.Lens
+import qualified Data.HashMap.Strict as HashMap
 import           Data.List
 import           Data.Maybe (fromMaybe)
 import qualified Data.Map as Map
 import           Graphics.Vty.Attributes
-import           Irc.Identifier
 
 -- | Draw the image lines associated with the @/windows@ command.
 windowsImages :: WindowsFilter -> ClientState -> [Image']
@@ -92,7 +93,7 @@ renderedFocus pal focus =
     ChannelFocus network channel ->
       text' (view palLabel pal) network <>
       char defAttr ':' <>
-      text' (view palLabel pal) (idText channel)
+      coloredIdentifier pal NormalIdentifier HashMap.empty channel
 
 renderedWindowInfo :: Palette -> Window -> Image'
 renderedWindowInfo pal win =


### PR DESCRIPTION
BREAKING CHANGES:
- Renames nick-colors to identifier-colors.
- Removes command-prompt (unused).
- Removes options for cmodes, umodes, and snomasks from palette.