### PR TITLE
Extract and improve documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[doc/*.adoc]
+end_of_line = lf
+max_line_length = 76
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.hs]
+indent_size = 2
+indent_style = space
+tab_width = 8
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,7 @@
+# glirc Documentation
+
+For auto-generated Haddock documentation, see `docs`.
+
+The command documentation is written in a subset of AsciiDoc,
+and is added back into glirc at compile time.
+Please consult `#glirc` on Libera.Chat before modifying it.

--- a/doc/cmds_chanop.adoc
+++ b/doc/cmds_chanop.adoc
@@ -64,4 +64,4 @@ See also: kick, kickban
 
 View or set the topic of the current channel.
 
-Tab-completion with no `message` specified will load the current topic for editing.
+Tab-completion with no `message` specified will load the current topic.

--- a/doc/cmds_chanop.adoc
+++ b/doc/cmds_chanop.adoc
@@ -1,0 +1,67 @@
+= Channel Management Commands
+:toc:
+
+== /invite
+
+Invite a user to the current channel.
+
+== /kick
+
+Kick a user from the current channel.
+
+See also: kickban, remove
+
+== /kickban
+
+Ban and kick a user from the current channel.
+
+Users are banned by hostname match.
+
+See also: kick, remove
+
+== /masks
+
+Show mask lists for current channel.
+
+The `mode` argument is typically one of the following:
+
+`b`: bans +
+`i`: invite exemptions (op view only) +
+`e`: ban exemptions (op view only) +
+`q`: quiets (on Charybdis/Solanum-based networks)
+
+== /mode
+
+Set IRC modes.
+
+When executed in a channel window, mode changes are applied to the channel.
+When executed in a network window, mode changes are applied to your user.
+
+This command has parameter sensitive tab-completion.
+
+See also: masks, channelinfo
+
+=== Examples
+
+Removing the topic lock: `+/mode -t+` +
+Setting a ban:           `+/mode +b *!*@hostname+` +
+Removing a quiet:        `+/mode -q *!*@hostname+` +
+Voicing two users:       `+/mode +vv user1 user2+` +
+Demoting an op to voice: `+/mode +v-o user1 user1+`
+
+== /remove
+
+Remove a user from the current channel.
+
+Remove works like /kick except it results in a PART.
+
+Not all servers support removal in this manner.
+Refer to your server/network's documentation.
+
+See also: kick, kickban
+
+== /topic
+
+View or set the topic of the current channel.
+
+Tab-completion with no `message` specified will load the current topic for editing.

--- a/doc/cmds_chanop.adoc
+++ b/doc/cmds_chanop.adoc
@@ -43,11 +43,11 @@ See also: masks, channelinfo
 
 === Examples
 
-Removing the topic lock: `+/mode -t+` +
-Setting a ban:           `+/mode +b *!*@hostname+` +
-Removing a quiet:        `+/mode -q *!*@hostname+` +
-Voicing two users:       `+/mode +vv user1 user2+` +
-Demoting an op to voice: `+/mode +v-o user1 user1+`
+`+/mode -t+`               - Remove the topic lock +
+`+/mode +b *!*@hostname+`  - Set a ban +
+`+/mode -q *!*@hostname+`  - Remove a quiet +
+`+/mode +vv user1 user2+`  - Voice two users +
+`+/mode +v-o user1 user1+` - Demote an op to voice
 
 == /remove
 

--- a/doc/cmds_chat.adoc
+++ b/doc/cmds_chat.adoc
@@ -1,0 +1,203 @@
+= Chat Commands
+:toc:
+
+== /join
+
+Join the given channels.
+
+Multiple channels and keys may be provided as comma-separated lists.
+
+When keys are provided, they should occur in the same order as the channels.
+
+=== Examples
+
+`+/join #friends+` +
+`+/join #secret thekey+` +
+`+/join #secret1,#secret2,#public key1,key2+`
+
+See also: channel, clear, part
+
+== /me
+
+Sends an action message to the currently focused channel.
+Most clients will render these messages prefixed with
+only your nickname as though describing an action.
+
+=== Examples
+
+`+/me shrugs+`
+
+See also: notice, msg, say
+
+== /msg
+
+Send a chat message to a user or a channel.
+
+Multiple targets may be provided as a comma-separated list.
+
+On servers with STATUSMSG support,
+the channel name can be prefixed with a sigil to
+restrict the recipients to those with the given mode.
+
+=== Examples
+
+`+/msg buddy I'm sending you a message.+` +
+`+/msg #friends This message is for the whole channel.+` +
+`+/msg him,her I'm chatting with two people.+` +
+`+/msg @#users This message is only for ops!+`
+
+See also: notice, me, say
+
+== /part
+
+Leave the currently-focused channel,
+optionally with the provided message.
+
+=== Examples
+
+`+/part+` +
+`+/part It's not me, it's you+`
+
+See also: clear, join, quit
+
+== /query
+
+Switch the client focus to the given
+target and optionally send a message to that target.
+
+=== Examples
+
+`+/q libera:#haskell+` +
+`+/q #haskell+` +
+`+/q lambdabot @messages+` +
+`+/q irc_friend How are you?+`
+
+See also: msg channel focus
+
+== /say
+
+Send a message to the current chat window.
+
+This can be useful for sending a chat message with
+a leading '/' to the current chat window.
+
+=== Examples
+
+`+/say /help is the right place to start!+`
+
+See also: notice, me, msg
+
+== /away
+
+Mark yourself as away.
+The away message is used by the server to update
+status in /whois and to provide automated responses.
+
+Omit the `message` parameter to clear your away status.
+
+=== Examples
+
+`+/away Out getting some sun+` +
+`+/away+`
+
+== /channelinfo
+
+Show information about the current channel.
+Information includes topic, creation time, URL, and modes.
+
+See also: masks, mode, topic, users
+
+== /ctcp
+
+Client-to-client protocol (CTCP) commands can be used
+to query information from another user's client application
+directly. Common CTCP commands include: ACTION, PING, VERSION,
+USERINFO, CLIENTINFO, and TIME.
+
+glirc does not automatically respond to CTCP commands.
+
+=== Parameters
+
+`target`    - Comma-separated list of nicknames and channels +
+`command`   - CTCP command name +
+`arguments` - CTCP command arguments
+
+=== Examples
+
+`+/ctcp myfriend VERSION+` +
+`+/ctcp myfriend TIME+`
+
+== /knock
+
+Request entry to an invite-only channel.
+
+== /monitor
+
+Monitor is a protocol for getting server-side notifications
+when users become online/offline.
+
+=== Subcommands
+
+`+/monitor + target[,target2]*+` - Add nicknames to monitor list +
+`+/monitor - target[,target2]*+` - Remove nicknames to monitor list +
+`+/monitor C+`                   - Clear monitor list +
+`+/monitor L+`                   - Show monitor list +
+`+/monitor S+`                   - Show status of nicknames on monitor list
+
+== /names
+
+Show the user list for the current channel.
+Detailed view (default key F2) shows full hostmask.
+
+See also: channelinfo, masks
+
+== /nick
+
+Change your nickname.
+
+=== Examples
+
+`+/nick guest123+` +
+`+/nick better_nick+`
+
+== /notice
+
+Send a chat notice to a user or a channel.
+
+Notice messages were originally intended to be used by bots.
+Different clients will render these in different ways.
+
+Multiple targets may be provided as a comma-separated list.
+
+On servers with STATUSMSG support,
+the channel name can be prefixed with a sigil to
+restrict the recipients to those with the given mode.
+
+=== Examples
+
+`+/notice buddy I'm sending you a notice.+` +
+`+/notice #friends This notice is for the whole channel.+` +
+`+/notice him,her I'm informing two people.+` +
+`+/notice @#users This notice is only for ops!+`
+
+See also: me, msg, say
+
+== /operwall
+
+Send a network-wide WALLOPS message to opers only.
+
+See also: me, msg, say
+
+== /wallops
+
+Send a network-wide WALLOPS message.
+These messages go out to users who have the 'w' usermode set.
+
+See also: me, msg, say
+
+== /quote
+
+Send a raw IRC command.
+
+The argument to this command is sent as-is.
+No additional word-splitting is done.

--- a/doc/cmds_chat.adoc
+++ b/doc/cmds_chat.adoc
@@ -65,14 +65,14 @@ See also: clear, join, quit
 Switch the client focus to the given
 target and optionally send a message to that target.
 
+See also: msg, channel, focus
+
 === Examples
 
 `+/q libera:#haskell+` +
 `+/q #haskell+` +
 `+/q lambdabot @messages+` +
 `+/q irc_friend How are you?+`
-
-See also: msg channel focus
 
 == /say
 

--- a/doc/cmds_client.adoc
+++ b/doc/cmds_client.adoc
@@ -1,0 +1,88 @@
+= Client Commands
+:toc:
+
+== /exit
+
+Exit the client immediately.
+
+== /reload
+
+Reload the client configuration file.
+
+If `filename` is provided it will be used to reload.
+Otherwise the previously loaded configuration file will be reloaded.
+
+== /extension
+
+Run a command provided by an extension.
+
+`extension` should be the name of a loaded extension with
+a process_command callback.
+
+== /palette
+
+Show the current palette settings and a color chart to help pick new colors.
+
+== /digraphs
+
+Show the table of digraphs. A digraph is a pair of characters
+that can be used together to represent an uncommon character.
+Type the two-character digraph corresponding to the desired
+output character and then press M-k (default binding).
+
+The digraphs list is searchable with `+/grep+`.
+
+See also: grep
+
+== /keymap
+
+Show the key binding map.
+
+Key bindings can be changed in configuration file.
+Run `+glirc --config-format+` for details.
+
+== /rtsstats
+
+Show the GHC RTS statistics.
+
+== /exec
+
+Execute a command synchnonously, optionally sending the output to IRC.
+
+Arguments to this command are:
+`+[-n[network]] [-c[channel]] [-i input] command [arguments...]+`
+
+`input` is sent to the standard input of the command.
+
+When neither `network` nor `channel` are specified,
+output goes to client window (focus name "*").
+When `network` is specified,
+output is sent as raw IRC traffic to the network.
+When `channel` is specified,
+output is sent as chat to the given channel on the current network.
+When `network` and `channel` are specified,
+output is sent as chat to the given channel on the given network.
+
+`arguments` is split on spaces into words before being
+processed by getopt. Use Haskell string literal syntax to
+create arguments with escaped characters and spaces inside.
+
+== /url
+
+Open a URL seen in chat.
+
+The URL is opened using the executable configured under `url-opener`.
+
+When this command is active in the textbox,
+chat messages are filtered to only show ones with URLs.
+
+When `number` is omitted it defaults to 1.
+The number selects the URL to open, counting back from the most recent.
+
+== /help
+
+Show command documentation.
+
+When `command` is omitted, a list of all commands and macros is shown.
+When `command` is specified, detailed help for that command is shown.
+

--- a/doc/cmds_integration.adoc
+++ b/doc/cmds_integration.adoc
@@ -5,15 +5,18 @@
 
 Send command directly to ZNC.
 
-The advantage of this over `+/msg+` is that responses are not broadcast to call clients.
+The advantage of this over `+/msg+` is that
+responses are not broadcast to call clients.
 
 == /znc-playback
 
 Request playback from the ZNC `playback` module.
 Note that the playback module is not installed in ZNC by default!
 
-When `date` is omitted, uses the most recent date in the past that makes sense.
-When both `time` and `date` are omitted, all playback is requested.
+When `date` is omitted,
+uses the most recent date in the past that makes sense.
+When both `time` and `date` are omitted,
+all playback is requested.
 
 Time format: `HOURS:MINUTES` (example: 7:00)
 

--- a/doc/cmds_integration.adoc
+++ b/doc/cmds_integration.adoc
@@ -1,0 +1,21 @@
+= Integrations
+:toc:
+
+== /znc
+
+Send command directly to ZNC.
+
+The advantage of this over `+/msg+` is that responses are not broadcast to call clients.
+
+== /znc-playback
+
+Request playback from the ZNC `playback` module.
+Note that the playback module is not installed in ZNC by default!
+
+When `date` is omitted, uses the most recent date in the past that makes sense.
+When both `time` and `date` are omitted, all playback is requested.
+
+Time format: `HOURS:MINUTES` (example: 7:00)
+
+Date format: `YEAR-MONTH-DAY` (example: 2016-06-16)
+

--- a/doc/cmds_net.adoc
+++ b/doc/cmds_net.adoc
@@ -1,0 +1,34 @@
+= Connection Commands
+:toc:
+
+== /connect
+
+Connect to `network` by name.
+
+If `network` does not correspond to the name of a server in the config,
+it is treated as a hostname.
+
+== /reconnect
+
+(Re)connect to the currently-focused server.
+
+== /quit
+
+Gracefully disconnect the current network connection,
+optionally sending the provided reason.
+
+See also: disconnect, exit
+
+== /disconnect
+
+Immediately terminate the current network connection.
+
+See also: quit, exit
+
+== /cert
+
+Show the TLS certificate for the current connection.
+
+== /umode
+
+Apply a user-mode change.

--- a/doc/cmds_net.adoc
+++ b/doc/cmds_net.adoc
@@ -25,10 +25,28 @@ Immediately terminate the current network connection.
 
 See also: quit, exit
 
+== /umode
+
+Apply a user-mode change. 
+
 == /cert
 
 Show the TLS certificate for the current connection.
 
-== /umode
+== /new-self-signed-cert
 
-Apply a user-mode change.
+Generate a new self-signed client certificate for
+network service identification using CertFP.
+
+The generated certificate can be used via the per-server
+`tls-client-cert` and `tls-client-key-password` (if applicable) keys
+in your config file. 
+
+This command generates an RSA key pair by default.
+This may change in the future.
+
+=== Parameters
+
+`filename`:   Certificate and private key PEM output +
+`keysize`:    Public-key size (default 2048, range 1024-8192) +
+`passphrase`: Optional AES-128 private key passphrase

--- a/doc/cmds_oper.adoc
+++ b/doc/cmds_oper.adoc
@@ -1,0 +1,102 @@
+= Operator Commands
+:toc:
+
+== /oper
+
+Authenticate as a server operator.
+
+== /kill
+
+Kill a client connection to the server.
+
+== /kline
+
+Ban a client from the server.
+
+== /unkline
+
+Unban a client from the server.
+
+== /undline
+
+Unban a client from the server.
+
+== /unxline
+
+Unban a gecos from the server.
+
+== /unresv
+
+Unban a channel or nickname from the server.
+
+== /testline
+
+Check matching I/K/D lines for a `[[nick!]user@]host`.
+
+== /testkline
+
+Check matching K/D lines for a `[user@]host`.
+
+== /testgecos
+
+Check matching X lines for a `gecos`.
+
+== /testmask
+
+Test how many local and global clients match a mask.
+
+== /masktrace
+
+Outputs a list of local users matching the given masks.
+
+== /chantrace
+
+Outputs a list of channel members in etrace format.
+
+== /trace
+
+Outputs a list users on a server.
+
+== /etrace
+
+Outputs a list users on a server.
+
+== /map
+
+Display network map.
+
+== /sconnect
+
+Connect two servers together.
+
+== /squit
+
+Split a server away from your side of the network.
+
+== /modload
+
+Load an IRCd module.
+
+== /modunload
+
+Unload an IRCd module.
+
+== /modlist
+
+List loaded IRCd modules.
+
+== /modrestart
+
+Reload all IRCd modules.
+
+== /modreload
+
+Reload an IRCd module.
+
+== /grant
+
+Manually assign a privset to a user.
+
+== /privs
+
+Check operator privileges of the target.

--- a/doc/cmds_queries.adoc
+++ b/doc/cmds_queries.adoc
@@ -1,0 +1,95 @@
+= Queries
+:toc:
+
+== /who
+
+Send WHO query to server with given arguments.
+
+If no query is provided, shows the results of the previous query.
+
+== /whois
+
+Send WHOIS query to server with given arguments.
+
+== /whowas
+
+Send WHOWAS query to server with given arguments.
+
+== /ison
+
+Send ISON query to server with given arguments.
+
+See also: monitor
+
+== /userhost
+
+Send USERHOST query to server with given arguments.
+
+== /time
+
+Send TIME query to server with given arguments.
+
+== /stats
+
+Send STATS query to server with given arguments.
+
+== /lusers
+
+Send LUSERS query to a given server.
+
+== /users
+
+Send USERS query to a given server.
+
+== /motd
+
+Send MOTD query to server.
+
+== /admin
+
+Send ADMIN query to server.
+
+== /rules
+
+Send RULES query to server.
+
+== /info
+
+Send INFO query to server.
+
+== /list
+
+View the list of public channels on the server.
+
+Sends a LIST query and caches the result;
+on larger networks, this may take several seconds to complete.
+The view may be exited while loading.
+
+`clientarg` is an optionally-comma-separated list of options.
+A single comma may be used to denote an empty list.
+
+`serverarg` is sent as-is to the server.
+It is generally used as the ELIST parameter to LIST.
+glirc does not validate this parameter against the ELIST ISUPPORT token.
+
+=== Client Options
+
+`>n`: Show only channels with more than `n` users. +
+`<n`: Show only channels with less than `n` users. +
+`~`: Force a refresh of the list.
+
+=== Examples
+
+`+/list+`          - List public channels.
+`+/list >99+`      - List public channels with at least 100 users.
+`+/list >50<1000+` - List public channels with between 51 and 999 users.
+`+/list ~ <20+`    - List public channels with fewer than 20 users. 
+`+/list , *-ops+`  - List public channels whose names end with "-ops".
+
+== /links
+
+Send LINKS query to server with given arguments.
+
+== /version
+
+Send VERSION query to server.

--- a/doc/cmds_toggles.adoc
+++ b/doc/cmds_toggles.adoc
@@ -1,0 +1,32 @@
+= Toggles
+:toc:
+
+== /toggle-detail
+
+Toggle detailed message view.
+
+== /toggle-activity-bar
+
+Toggle detailed detailed activity information in status bar.
+
+== /toggle-show-ping
+
+Toggle visibility of ping round-trip time.
+
+== /toggle-metadata
+
+Toggle visibility of metadata in chat windows.
+
+== /toggle-layout
+
+Toggle multi-window layout mode.
+
+== /toggle-editor
+
+Toggle between single-line and multi-line editor mode.
+
+== /toggle-edit-lock
+
+Toggle editor lock mode.
+
+When the editor is locked, Enter (or C-j) does nothing.

--- a/doc/cmds_window.adoc
+++ b/doc/cmds_window.adoc
@@ -9,9 +9,9 @@ See also: focus
 
 === Examples
 
-`/c libera:#haskell` +
-`/c #haskell` +
-`/c libera:`
+`+/c libera:#haskell+` +
+`+/c #haskell+` +
+`+/c libera:+`
 
 == /focus
 

--- a/doc/cmds_window.adoc
+++ b/doc/cmds_window.adoc
@@ -1,0 +1,145 @@
+= Window Commands
+:toc:
+
+== /channel
+
+Set the current focused window.
+
+See also: focus
+
+=== Examples
+
+`/c libera:#haskell` +
+`/c #haskell` +
+`/c libera:`
+
+== /focus
+
+Set the current focused window.
+
+When only `network` is specified this switches to the network status window.
+When `network` and `target` are specified this switches to that chat window.
+
+Nickname and channels can be specified in the `target` parameter.
+
+See also: query, channel
+
+== /clear
+
+Clear a window.
+
+If no arguments are provided the current window is cleared.
+If `network` is provided the that network window is cleared.
+If `network` and `channel` are provided that chat window is cleared.
+If `network` is provided and `channel` is `*` all windows for that network are cleared.
+
+If a window is cleared and no longer active that window will be removed from the client.
+
+== /windows
+
+Show a list of all windows.
+
+`kind`, if specified, is one of `networks`, `channels` or `users`,
+and limits the list to the type of window specified.
+
+== /splits
+
+This command defines the set of focuses that will
+always be visible, even when unfocused.
+If no focuses are listed, the set will be cleared.
+
+=== Examples
+
+`+/splits #haskell #haskell-lens nickserv+` +
+`+/splits * libera:#haskell libera:chanserv+` +
+`+/splits+`
+
+See also: splits+, splits-
+
+== /splits+
+
+Add focuses to the splits set.
+Omit the list of focuses to add the current window.
+
+=== Examples
+
+`+/splits+ #haskell #haskell-lens+` +
+`+/splits+ libera:#libera+` +
+`+/splits++`
+
+== /splits-
+
+Remove focuses from the splits set.
+Omit the list of focuses to remove the current window.
+
+== /ignore
+
+Toggle the soft-ignore on each of the space-delimited given
+nicknames. Ignores can use `*` (many) and `?` (one) wildcards.
+Masks can be of the form `nick[[!user]@host]`
+and use a case-insensitive comparison.
+
+If no masks are specified the current ignore list is displayed.
+
+=== Examples
+
+`+/ignore+` +
+`+/ignore nick1 nick2 nick3+` +
+`+/ignore nick@host+` +
+`+/ignore nick!user@host+` +
+`+/ignore *@host+` +
+`+/ignore *!baduser@*+`
+
+== /grep
+
+Filter view contents using a regular expression.
+
+Clear the regular expression by calling this without an argument.
+
+`/grep` is case-sensitive by default.
+
+=== Flags
+
+`-A n` - Show n messages after match
+`-B n` - Show n messages before match
+`-C n` - Show n messages before and after match
+`-F`   - Use plain-text match instead of regular expression
+`-i`   - Case insensitive match
+`-v`   - Invert pattern match
+`-m n` - Limit results to n matches
+`--`   - Stop processing flags
+
+== /dump
+
+Dump the current window's contents to a file.
+
+This command always outputs as if detailed mode is active.
+
+== /mentions
+
+Show a list of all messages that were highlighted as important.
+
+When using `/grep` the important messages are those matching
+the regular expression instead.
+
+== /setwindow
+
+Set window property.
+
+=== Properties
+
+`louder`: Upgrades normal messages to important. +
+`loud`: Uses default message importance. +
+`imponly`: Downgrades normal messages to boring. +
+`quiet`: Downgrades important messages to normal. +
+`quieter`: Downgrades message importance one step. +
+`silent`: Downgrades message importance to boring.
+
+`show` / `hide`: Toggles if window appears in window command shortcuts.
+
+== /setname
+
+Set window shortcut letter. If no letter is provided the next available
+letter will automatically be assigned.
+
+Available letters are configured in the `window-names` configuration setting.

--- a/doc/cmds_window.adoc
+++ b/doc/cmds_window.adoc
@@ -28,12 +28,13 @@ See also: query, channel
 
 Clear a window.
 
-If no arguments are provided the current window is cleared.
-If `network` is provided the that network window is cleared.
-If `network` and `channel` are provided that chat window is cleared.
-If `network` is provided and `channel` is `*` all windows for that network are cleared.
+If no arguments are provided, the current window is cleared.
+If `channel` is not provided, the `network` window is cleared.
+If `channel` is `*`, all windows for `network` are cleared.
+If `channel` is provided, that chat window is cleared.
 
-If a window is cleared and no longer active that window will be removed from the client.
+If a window is cleared and no longer active (e.g. due to leaving a channel),
+that window will be removed entirely.
 
 == /windows
 
@@ -142,4 +143,6 @@ Set window property.
 Set window shortcut letter. If no letter is provided the next available
 letter will automatically be assigned.
 
-Available letters are configured in the `window-names` configuration setting.
+Available letters are configured in the `window-names` config setting,
+which defaults to the characters available from
+the top letter and number rows on a QWERTY keyboard.

--- a/glirc.cabal
+++ b/glirc.cabal
@@ -16,7 +16,7 @@ copyright:           2016-2019 Eric Mertens
 category:            Network
 extra-source-files:  exec/linux_exported_symbols.txt
                      exec/macos_exported_symbols.txt
-extra-doc-files:     glirc.1 ChangeLog.md README.md
+extra-doc-files:     glirc.1 ChangeLog.md README.md doc/*.adoc
 homepage:            https://github.com/glguy/irc-core
 bug-reports:         https://github.com/glguy/irc-core/issues
 tested-with:         GHC == 9.0.2, GHC == 9.4.7, GHC == 9.8.1

--- a/glirc.cabal
+++ b/glirc.cabal
@@ -76,6 +76,7 @@ library
     Client.Commands.Chat
     Client.Commands.Certificate
     Client.Commands.Connection
+    Client.Commands.Docs
     Client.Commands.Exec
     Client.Commands.Interpolation
     Client.Commands.Operator
@@ -93,6 +94,7 @@ library
     Client.Configuration.Notifications
     Client.Configuration.ServerSettings
     Client.Configuration.Sts
+    Client.Docs
     Client.EventLoop
     Client.EventLoop.Actions
     Client.EventLoop.Errors

--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -228,55 +228,55 @@ commandsList =
   [ Command
       (pure "exit")
       (pure ())
-      $(clientDocs >>= cmdDoc "exit")
+      $(clientDocs `cmdDoc` "exit")
     $ ClientCommand cmdExit noClientTab
 
   , Command
       (pure "reload")
       (optionalArg (simpleToken "[filename]"))
-      $(clientDocs >>= cmdDoc "reload")
+      $(clientDocs `cmdDoc` "reload")
     $ ClientCommand cmdReload tabReload
 
   , Command
       (pure "extension")
       (liftA2 (,) (simpleToken "extension") (remainingArg "arguments"))
-      $(clientDocs >>= cmdDoc "extension")
+      $(clientDocs `cmdDoc` "extension")
     $ ClientCommand cmdExtension simpleClientTab
 
   , Command
       (pure "palette")
       (pure ())
-      $(clientDocs >>= cmdDoc "palette")
+      $(clientDocs `cmdDoc` "palette")
     $ ClientCommand cmdPalette noClientTab
 
   , Command
       (pure "digraphs")
       (pure ())
-      $(clientDocs >>= cmdDoc "digraphs")
+      $(clientDocs `cmdDoc` "digraphs")
     $ ClientCommand cmdDigraphs noClientTab
 
   , Command
       (pure "keymap")
       (pure ())
-      $(clientDocs >>= cmdDoc "keymap")
+      $(clientDocs `cmdDoc` "keymap")
     $ ClientCommand cmdKeyMap noClientTab
 
   , Command
       (pure "rtsstats")
       (pure ())
-      $(clientDocs >>= cmdDoc "rtsstats")
+      $(clientDocs `cmdDoc` "rtsstats")
     $ ClientCommand cmdRtsStats noClientTab
 
   , Command
       (pure "exec")
       (remainingArg "arguments")
-      $(clientDocs >>= cmdDoc "exec")
+      $(clientDocs `cmdDoc` "exec")
     $ ClientCommand cmdExec simpleClientTab
 
   , Command
       (pure "url")
       optionalNumberArg
-      $(clientDocs >>= cmdDoc "url")
+      $(clientDocs `cmdDoc` "url")
     $ ClientCommand cmdUrl noClientTab
 
   , newCertificateCommand
@@ -284,7 +284,7 @@ commandsList =
   , Command
       (pure "help")
       (optionalArg (simpleToken "[command]"))
-      $(clientDocs >>= cmdDoc "help")
+      $(clientDocs `cmdDoc` "help")
     $ ClientCommand cmdHelp tabHelp
 
   ------------------------------------------------------------------------

--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, OverloadedStrings, ExistentialQuantification #-}
+{-# LANGUAGE BangPatterns, OverloadedStrings, TemplateHaskell, ExistentialQuantification #-}
 
 {-|
 Module      : Client.Commands
@@ -27,6 +27,7 @@ module Client.Commands
 
 import Client.Commands.Arguments.Parser (parse)
 import Client.Commands.Arguments.Spec (optionalArg, optionalNumberArg, remainingArg, simpleToken)
+import Client.Commands.Docs (clientDocs, cmdDoc)
 import Client.Commands.Exec
 import Client.Commands.Interpolation (resolveMacroExpansions, Macro(Macro), MacroSpec(MacroSpec))
 import Client.Commands.Recognizer (fromCommands, keys, recognize, Recognition(Exact), Recognizer)
@@ -227,93 +228,55 @@ commandsList =
   [ Command
       (pure "exit")
       (pure ())
-      "Exit the client immediately.\n"
+      $(clientDocs >>= cmdDoc "exit")
     $ ClientCommand cmdExit noClientTab
 
   , Command
       (pure "reload")
       (optionalArg (simpleToken "[filename]"))
-      "Reload the client configuration file.\n\
-      \\n\
-      \If \^Bfilename\^B is provided it will be used to reload.\n\
-      \Otherwise the previously loaded configuration file will be reloaded.\n"
+      $(clientDocs >>= cmdDoc "reload")
     $ ClientCommand cmdReload tabReload
 
   , Command
       (pure "extension")
       (liftA2 (,) (simpleToken "extension") (remainingArg "arguments"))
-      "Calls the process_command callback of the given extension.\n\
-      \\n\
-      \\^Bextension\^B should be the name of the loaded extension.\n"
+      $(clientDocs >>= cmdDoc "extension")
     $ ClientCommand cmdExtension simpleClientTab
 
   , Command
       (pure "palette")
       (pure ())
-      "Show the current palette settings and a color chart to help pick new colors.\n"
+      $(clientDocs >>= cmdDoc "palette")
     $ ClientCommand cmdPalette noClientTab
 
   , Command
       (pure "digraphs")
       (pure ())
-      "\^BDescription:\^B\n\
-      \\n\
-      \    Show the table of digraphs. A digraph is a pair of characters\n\
-      \    can be used together to represent an uncommon character. Type\n\
-      \    the two-character digraph corresponding to the desired output\n\
-      \    character and then press M-k (default binding).\n\
-      \\n\
-      \    Note that the digraphs list is searchable with /grep.\n\
-      \\n\
-      \\^BSee also:\^B grep\n"
+      $(clientDocs >>= cmdDoc "digraphs")
     $ ClientCommand cmdDigraphs noClientTab
 
   , Command
       (pure "keymap")
       (pure ())
-      "Show the key binding map.\n\
-      \\n\
-      \Key bindings can be changed in configuration file. See `glirc --config-format`.\n"
+      $(clientDocs >>= cmdDoc "keymap")
     $ ClientCommand cmdKeyMap noClientTab
 
   , Command
       (pure "rtsstats")
       (pure ())
-      "Show the GHC RTS statistics.\n"
+      $(clientDocs >>= cmdDoc "rtsstats")
     $ ClientCommand cmdRtsStats noClientTab
 
   , Command
       (pure "exec")
       (remainingArg "arguments")
-      "Execute a command synchnonously sending the to a configuration destination.\n\
-      \\n\
-      \\^Barguments\^B: [-n[network]] [-c[channel]] [-i input] command [arguments...]\n\
-      \\n\
-      \When \^Binput\^B is specified it is sent to the stdin.\n\
-      \\n\
-      \When neither \^Bnetwork\^B nor \^Bchannel\^B are specified output goes to client window (*).\n\
-      \When \^Bnetwork\^B is specified output is sent as raw IRC traffic to the network.\n\
-      \When \^Bchannel\^B is specified output is sent as chat to the given channel on the current network.\n\
-      \When \^Bnetwork\^B and \^Bchannel\^B are specified output is sent as chat to the given channel on the given network.\n\
-      \\n\
-      \\^Barguments\^B is divided on spaces into words before being processed\
-      \ by getopt. Use Haskell string literal syntax to create arguments with\
-      \ escaped characters and spaces inside.\n\
-      \\n"
+      $(clientDocs >>= cmdDoc "exec")
     $ ClientCommand cmdExec simpleClientTab
 
   , Command
       (pure "url")
       optionalNumberArg
-      "Open a URL seen in chat.\n\
-      \\n\
-      \The URL is opened using the executable configured under \^Burl-opener\^B.\n\
-      \\n\
-      \When this command is active in the textbox, chat messages are filtered to\
-      \ only show ones with URLs.\n\
-      \\n\
-      \When \^Bnumber\^B is omitted it defaults to \^B1\^B. The number selects the\
-      \ URL to open counting back from the most recent.\n"
+      $(clientDocs >>= cmdDoc "url")
     $ ClientCommand cmdUrl noClientTab
 
   , newCertificateCommand
@@ -321,10 +284,7 @@ commandsList =
   , Command
       (pure "help")
       (optionalArg (simpleToken "[command]"))
-      "Show command documentation.\n\
-      \\n\
-      \When \^Bcommand\^B is omitted a list of all commands is displayed.\n\
-      \When \^Bcommand\^B is specified detailed help for that command is shown.\n"
+      $(clientDocs >>= cmdDoc "help")
     $ ClientCommand cmdHelp tabHelp
 
   ------------------------------------------------------------------------

--- a/src/Client/Commands/Certificate.hs
+++ b/src/Client/Commands/Certificate.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Certificate
 Description : Certificate management commands
@@ -10,6 +10,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Certificate (newCertificateCommand) where
 
 import Client.Commands.Arguments.Spec
+import Client.Commands.Docs (netDocs, cmdDoc)
 import Client.Commands.TabCompletion (noClientTab)
 import Client.Commands.Types
 import Client.State (recordError, recordSuccess)
@@ -45,29 +46,7 @@ newCertificateCommand =
   Command
     (pure "new-self-signed-cert")
     (liftA2 (,) (simpleToken "filename") keysizeArg)
-      "\^BParameters:\^B\n\
-      \\n\
-      \    filename:   Certificate and private key PEM output\n\
-      \    keysize:    Public-key size (default 2048, range 1024-8192)\n\
-      \    passphrase: Optional AES-128 private key passphrase\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Generate a new self-signed certificate for network service\n\
-      \    identification.\n\
-      \\n\
-      \\^BExample command:\^B\n\
-      \\n\
-      \    /new-self-signed-cert /home/me/.glirc/config/my.pem 2048 SeCrEt\n\
-      \\n\
-      \\^BExample configuration:\^B\n\
-      \    servers:\n\
-      \      * name:                    \"fn\"\n\
-      \        hostname:                \"irc.libera.chat\"\n\
-      \        sasl: mechanism:         external\n\
-      \        tls:                     yes\n\
-      \        tls-client-cert:         \"my.pem\"\n\
-      \        tls-client-key-password: \"SeCrEt\"\n"
+    $(netDocs >>= cmdDoc "new-self-signed-cert")
     (ClientCommand cmdNewCert noClientTab)
 
 cmdNewCert :: ClientCommand (String, Maybe (Int, String))

--- a/src/Client/Commands/Certificate.hs
+++ b/src/Client/Commands/Certificate.hs
@@ -46,7 +46,7 @@ newCertificateCommand =
   Command
     (pure "new-self-signed-cert")
     (liftA2 (,) (simpleToken "filename") keysizeArg)
-    $(netDocs >>= cmdDoc "new-self-signed-cert")
+    $(netDocs `cmdDoc` "new-self-signed-cert")
     (ClientCommand cmdNewCert noClientTab)
 
 cmdNewCert :: ClientCommand (String, Maybe (Int, String))

--- a/src/Client/Commands/Channel.hs
+++ b/src/Client/Commands/Channel.hs
@@ -40,43 +40,43 @@ channelCommands = CommandSection "IRC channel management"
   [ Command
       (pure "mode")
       (fromMaybe [] <$> optionalArg (extensionArg "[modes]" modeParamArgs))
-      $(chanopDocs >>= cmdDoc "mode")
+      $(chanopDocs `cmdDoc` "mode")
     $ NetworkCommand cmdMode tabMode
 
   , Command
       (pure "masks")
       (simpleToken "mode")
-      $(chanopDocs >>= cmdDoc "masks")
+      $(chanopDocs `cmdDoc` "masks")
     $ ChannelCommand cmdMasks noChannelTab
 
   , Command
       (pure "invite")
       (simpleToken "nick")
-      $(chanopDocs >>= cmdDoc "invite")
+      $(chanopDocs `cmdDoc` "invite")
     $ ChannelCommand cmdInvite simpleChannelTab
 
   , Command
       (pure "topic")
       (remainingArg "message")
-      $(chanopDocs >>= cmdDoc "topic")
+      $(chanopDocs `cmdDoc` "topic")
     $ ChannelCommand cmdTopic tabTopic
 
   , Command
       (pure "kick")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      $(chanopDocs >>= cmdDoc "kick")
+      $(chanopDocs `cmdDoc` "kick")
     $ ChannelCommand cmdKick simpleChannelTab
 
   , Command
       (pure "kickban")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      $(chanopDocs >>= cmdDoc "kickban")
+      $(chanopDocs `cmdDoc` "kickban")
     $ ChannelCommand cmdKickBan simpleChannelTab
 
   , Command
       (pure "remove")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      $(chanopDocs >>= cmdDoc "remove")
+      $(chanopDocs `cmdDoc` "remove")
     $ ChannelCommand cmdRemove simpleChannelTab
 
   ]

--- a/src/Client/Commands/Channel.hs
+++ b/src/Client/Commands/Channel.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Channel
 Description : Channel management command implementations
@@ -10,6 +10,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Channel (channelCommands) where
 
 import Client.Commands.Arguments.Spec
+import Client.Commands.Docs (chanopDocs, cmdDoc)
 import Client.Commands.TabCompletion (activeNicks, noChannelTab, simpleChannelTab, simpleTabCompletion)
 import Client.Commands.Types
 import Client.Commands.WordCompletion (plainWordCompleteMode)
@@ -39,76 +40,43 @@ channelCommands = CommandSection "IRC channel management"
   [ Command
       (pure "mode")
       (fromMaybe [] <$> optionalArg (extensionArg "[modes]" modeParamArgs))
-      "Sets IRC modes.\n\
-      \\n\
-      \Examples:\n\
-      \Setting a ban:           /mode +b *!*@hostname\n\
-      \Removing a quiet:        /mode -q *!*@hostname\n\
-      \Voicing two users:       /mode +vv user1 user2\n\
-      \Demoting an op to voice: /mode +v-o user1 user1\n\
-      \\n\
-      \When executed in a network window, mode changes are applied to your user.\n\
-      \When executed in a channel window, mode changes are applied to the channel.\n\
-      \\n\
-      \This command has parameter sensitive tab-completion.\n\
-      \\n\
-      \See also: /masks /channelinfo\n"
+      $(chanopDocs >>= cmdDoc "mode")
     $ NetworkCommand cmdMode tabMode
 
   , Command
       (pure "masks")
       (simpleToken "mode")
-      "Show mask lists for current channel.\n\
-      \\n\
-      \Common \^Bmode\^B values:\n\
-      \\^Bb\^B: bans\n\
-      \\^Bq\^B: quiets\n\
-      \\^BI\^B: invite exemptions (op view only)\n\
-      \\^Be\^B: ban exemption (op view only)s\n\
-      \\n\
-      \To populate the mask lists for the first time use: /mode \^Bmode\^B\n\
-      \\n\
-      \See also: /mode\n"
+      $(chanopDocs >>= cmdDoc "masks")
     $ ChannelCommand cmdMasks noChannelTab
 
   , Command
       (pure "invite")
       (simpleToken "nick")
-      "Invite a user to the current channel.\n"
+      $(chanopDocs >>= cmdDoc "invite")
     $ ChannelCommand cmdInvite simpleChannelTab
 
   , Command
       (pure "topic")
       (remainingArg "message")
-      "Set the topic on the current channel.\n\
-      \\n\
-      \Tab-completion with no \^Bmessage\^B specified will load the current topic for editing.\n"
+      $(chanopDocs >>= cmdDoc "topic")
     $ ChannelCommand cmdTopic tabTopic
 
   , Command
       (pure "kick")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      "Kick a user from the current channel.\n\
-      \\n\
-      \See also: /kickban /remove\n"
+      $(chanopDocs >>= cmdDoc "kick")
     $ ChannelCommand cmdKick simpleChannelTab
 
   , Command
       (pure "kickban")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      "Ban and kick a user from the current channel.\n\
-      \\n\
-      \Users are banned by hostname match.\n\
-      \See also: /kick /remove\n"
+      $(chanopDocs >>= cmdDoc "kickban")
     $ ChannelCommand cmdKickBan simpleChannelTab
 
   , Command
       (pure "remove")
       (liftA2 (,) (simpleToken "nick") (remainingArg "reason"))
-      "Remove a user from the current channel.\n\
-      \\n\
-      \Remove works like /kick except it results in a PART.\n\
-      \See also: /kick /kickban\n"
+      $(chanopDocs >>= cmdDoc "remove")
     $ ChannelCommand cmdRemove simpleChannelTab
 
   ]

--- a/src/Client/Commands/Chat.hs
+++ b/src/Client/Commands/Chat.hs
@@ -40,103 +40,103 @@ chatCommands = CommandSection "IRC commands"
   [ Command
       ("join" :| ["j"])
       (liftA2 (,) (simpleToken "channels") (optionalArg (simpleToken "[keys]")))
-      $(chatDocs >>= cmdDoc "join")
+      $(chatDocs `cmdDoc` "join")
     $ NetworkCommand cmdJoin simpleNetworkTab
 
   , Command
       (pure "part")
       (remainingArg "reason")
-      $(chatDocs >>= cmdDoc "part")
+      $(chatDocs `cmdDoc` "part")
     $ ChannelCommand cmdPart simpleChannelTab
 
   , Command
       (pure "msg")
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      $(chatDocs >>= cmdDoc "msg")
+      $(chatDocs `cmdDoc` "msg")
     $ NetworkCommand cmdMsg simpleNetworkTab
 
   , Command
       (pure "me")
       (remainingArg "message")
-      $(chatDocs >>= cmdDoc "me")
+      $(chatDocs `cmdDoc` "me")
     $ ChatCommand cmdMe simpleChannelTab
 
   , Command
       (pure "say")
       (remainingArg "message")
-      $(chatDocs >>= cmdDoc "say")
+      $(chatDocs `cmdDoc` "say")
     $ ChatCommand cmdSay simpleChannelTab
 
   , Command
       ("query" :| ["q"])
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      $(chatDocs >>= cmdDoc "query")
+      $(chatDocs `cmdDoc` "query")
     $ ClientCommand cmdQuery simpleClientTab
 
   , Command
       (pure "notice")
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      $(chatDocs >>= cmdDoc "notice")
+      $(chatDocs `cmdDoc` "notice")
     $ NetworkCommand cmdNotice simpleNetworkTab
 
   , Command
       (pure "wallops")
       (remainingArg "message to +w users")
-      $(chatDocs >>= cmdDoc "wallops")
+      $(chatDocs `cmdDoc` "wallops")
     $ NetworkCommand cmdWallops simpleNetworkTab
 
   , Command
       (pure "operwall")
       (remainingArg "message to +z opers")
-      $(chatDocs >>= cmdDoc "operwall")
+      $(chatDocs `cmdDoc` "operwall")
     $ NetworkCommand cmdOperwall simpleNetworkTab
 
   , Command
       (pure "ctcp")
       (liftA3 (,,) (simpleToken "target") (simpleToken "command") (remainingArg "arguments"))
-      $(chatDocs >>= cmdDoc "ctcp")
+      $(chatDocs `cmdDoc` "ctcp")
     $ NetworkCommand cmdCtcp simpleNetworkTab
 
   , Command
       (pure "nick")
       (simpleToken "nick")
-      $(chatDocs >>= cmdDoc "nick")
+      $(chatDocs `cmdDoc` "nick")
     $ NetworkCommand cmdNick simpleNetworkTab
 
   , Command
       (pure "away")
       (remainingArg "message")
-      $(chatDocs >>= cmdDoc "away")
+      $(chatDocs `cmdDoc` "away")
     $ NetworkCommand cmdAway simpleNetworkTab
 
   , Command
       (pure "names")
       (pure ())
-      $(chatDocs >>= cmdDoc "names")
+      $(chatDocs `cmdDoc` "names")
     $ ChannelCommand cmdChanNames noChannelTab
 
   , Command
       (pure "channelinfo")
       (pure ())
-      $(chatDocs >>= cmdDoc "channelinfo")
+      $(chatDocs `cmdDoc` "channelinfo")
     $ ChannelCommand cmdChannelInfo noChannelTab
 
   , Command
       (pure "knock")
       (liftA2 (,) (simpleToken "channel") (remainingArg "message"))
-      $(chatDocs >>= cmdDoc "knock")
+      $(chatDocs `cmdDoc` "knock")
     $ NetworkCommand cmdKnock simpleNetworkTab
 
   , Command
       (pure "quote")
       (remainingArg "raw IRC command")
-      $(chatDocs >>= cmdDoc "quote")
+      $(chatDocs `cmdDoc` "quote")
     $ NetworkCommand cmdQuote simpleNetworkTab
 
   , Command
       (pure "monitor")
       (extensionArg "[+-CLS]" monitorArgs)
-      $(chatDocs >>= cmdDoc "monitor")
+      $(chatDocs `cmdDoc` "monitor")
     $ NetworkCommand cmdMonitor simpleNetworkTab
 
   ]

--- a/src/Client/Commands/Chat.hs
+++ b/src/Client/Commands/Chat.hs
@@ -1,4 +1,4 @@
-{-# Language BangPatterns, OverloadedStrings #-}
+{-# Language BangPatterns, OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Chat
 Description : Common user IRC commands
@@ -31,6 +31,7 @@ import Irc.Commands
 import Irc.Identifier (Identifier, idText, mkId)
 import Irc.Message (IrcMsg(Privmsg, Notice, Ctcp), Source(Source))
 import Irc.RawIrcMsg (RawIrcMsg, parseRawIrcMsg)
+import Client.Commands.Docs (chatDocs, cmdDoc)
 
 chatCommands :: CommandSection
 chatCommands = CommandSection "IRC commands"
@@ -39,319 +40,106 @@ chatCommands = CommandSection "IRC commands"
   [ Command
       ("join" :| ["j"])
       (liftA2 (,) (simpleToken "channels") (optionalArg (simpleToken "[keys]")))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    channels: Comma-separated list of channels\n\
-      \    keys:     Comma-separated list of keys\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Join the given channels. When keys are provided, they should\n\
-      \    occur in the same order as the channels.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /join #friends\n\
-      \    /join #secret thekey\n\
-      \    /join #secret1,#secret2 key1,key2\n\
-      \\n\
-      \\^BSee also:\^B channel, clear, part\n"
+      $(chatDocs >>= cmdDoc "join")
     $ NetworkCommand cmdJoin simpleNetworkTab
 
   , Command
       (pure "part")
       (remainingArg "reason")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    reason: Optional message sent to channel as part reason\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Part from the current channel.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /part\n\
-      \    /part It's not me, it's you\n\
-      \\n\
-      \\^BSee also:\^B clear, join, quit\n"
+      $(chatDocs >>= cmdDoc "part")
     $ ChannelCommand cmdPart simpleChannelTab
 
   , Command
       (pure "msg")
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    target:  Comma-separated list of nicknames and channels\n\
-      \    message: Formatted message body\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Send a chat message to a user or a channel. On servers\n\
-      \    with STATUSMSG support, the channel name can be prefixed\n\
-      \    with a sigil to restrict the recipients to those with the\n\
-      \    given mode.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /msg buddy I'm sending you a message.\n\
-      \    /msg #friends This message is for the whole channel.\n\
-      \    /msg him,her I'm chatting with two people.\n\
-      \    /msg @#users This message is only for ops!\n\
-      \\n\
-      \\^BSee also:\^B notice, me, say\n"
+      $(chatDocs >>= cmdDoc "msg")
     $ NetworkCommand cmdMsg simpleNetworkTab
 
   , Command
       (pure "me")
       (remainingArg "message")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    message: Body of action message\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Sends an action message to the currently focused channel.\n\
-      \    Most clients will render these messages prefixed with\n\
-      \    only your nickname as though describing an action.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /me shrugs\n\
-      \\n\
-      \\^BSee also:\^B notice, msg, say\n"
+      $(chatDocs >>= cmdDoc "me")
     $ ChatCommand cmdMe simpleChannelTab
 
   , Command
       (pure "say")
       (remainingArg "message")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    message: Body of message\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Send a message to the current chat window.  This can be useful\n\
-      \    for sending a chat message with a leading '/' to the current\n\
-      \    chat window.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /say /help is the right place to start!\n\
-      \\n\
-      \\^BSee also:\^B notice, me, msg\n"
+      $(chatDocs >>= cmdDoc "say")
     $ ChatCommand cmdSay simpleChannelTab
 
   , Command
       ("query" :| ["q"])
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    target: Focus name\n\
-      \    message: Optional message\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    This command switches the client focus to the given\n\
-      \    target and optionally sends a message to that target.\n\
-      \\n\
-      \    Channel: \^_#channel\^_\n\
-      \    Channel: \^_network\^_:\^_#channel\^_\n\
-      \    User:    \^_nick\^_\n\
-      \    User:    \^_network\^_:\^_nick\^_\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /q fn:#haskell\n\
-      \    /q #haskell\n\
-      \    /q lambdabot @messages\n\
-      \    /q irc_friend How are you?\n\
-      \\n\
-      \\^BSee also:\^B msg channel focus\n"
+      $(chatDocs >>= cmdDoc "query")
     $ ClientCommand cmdQuery simpleClientTab
 
   , Command
       (pure "notice")
       (liftA2 (,) (simpleToken "target") (remainingArg "message"))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    target:  Comma-separated list of nicknames and channels\n\
-      \    message: Formatted message body\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Send a chat notice to a user or a channel. On servers\n\
-      \    with STATUSMSG support, the channel name can be prefixed\n\
-      \    with a sigil to restrict the recipients to those with the\n\
-      \    given mode. Notice messages were originally intended to be\n\
-      \    used by bots. Different clients will render these in different\n\
-      \    ways.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /notice buddy I'm sending you a message.\n\
-      \    /notice #friends This message is for the whole channel.\n\
-      \    /notice him,her I'm chatting with two people.\n\
-      \    /notice @#users This message is only for ops!\n\
-      \\n\
-      \\^BSee also:\^B me, msg, say\n"
+      $(chatDocs >>= cmdDoc "notice")
     $ NetworkCommand cmdNotice simpleNetworkTab
 
   , Command
       (pure "wallops")
       (remainingArg "message to +w users")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    message: Formatted message body\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Send a network-wide WALLOPS message. These message go out\n\
-      \    to users who have the 'w' usermode set.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /wallops Hi everyone, thanks for using this network!\n\
-      \\n\
-      \\^BSee also:\^B me, msg, say\n"
+      $(chatDocs >>= cmdDoc "wallops")
     $ NetworkCommand cmdWallops simpleNetworkTab
 
   , Command
       (pure "operwall")
       (remainingArg "message to +z opers")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    message: Formatted message body\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Send a network-wide WALLOPS message to opers. These message go\n\
-      \    out to opers who have the 'z' usermode set.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /operwall What's this even for?\n\
-      \\n\
-      \\^BSee also:\^B me, msg, say\n"
+      $(chatDocs >>= cmdDoc "operwall")
     $ NetworkCommand cmdOperwall simpleNetworkTab
 
   , Command
       (pure "ctcp")
       (liftA3 (,,) (simpleToken "target") (simpleToken "command") (remainingArg "arguments"))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    target:    Comma-separated list of nicknames and channels\n\
-      \    command:   CTCP command name\n\
-      \    arguments: CTCP command arguments\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Client-to-client protocol (CTCP) commands can be used\n\
-      \    to query information from another user's client application\n\
-      \    directly. Common CTCP commands include: ACTION, PING, VERSION,\n\
-      \    USERINFO, CLIENTINFO, and TIME. glirc does not automatically\n\
-      \    respond to CTCP commands.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /ctcp myfriend VERSION\n\
-      \    /ctcp myfriend CLIENTINFO\n"
+      $(chatDocs >>= cmdDoc "ctcp")
     $ NetworkCommand cmdCtcp simpleNetworkTab
 
   , Command
       (pure "nick")
       (simpleToken "nick")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    nick: New nickname\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Change your nickname on the currently focused server.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /nick guest123\n\
-      \    /nick better_nick\n"
+      $(chatDocs >>= cmdDoc "nick")
     $ NetworkCommand cmdNick simpleNetworkTab
 
   , Command
       (pure "away")
       (remainingArg "message")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    message: Optional away message\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Change your nickname on the currently focused server.\n\
-      \    Omit the message parameter to clear your away status.\n\
-      \    The away message is only used by the server to update\n\
-      \    status in /whois and to provide automated responses.\n\
-      \    It is not used by this client directly.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /away\n\
-      \    /away Out getting some sun\n"
+      $(chatDocs >>= cmdDoc "away")
     $ NetworkCommand cmdAway simpleNetworkTab
 
   , Command
       (pure "names")
       (pure ())
-      "\^BDescription:\^B\n\
-      \\n\
-      \    Show the user list for the current channel.\n\
-      \    Detailed view (default key F2) shows full hostmask.\n\
-      \    Hostmasks can be populated with /who #channel.\n\
-      \    Press ESC to exit the userlist.\n\
-      \\n\
-      \\^BSee also:\^B channelinfo, masks\n"
+      $(chatDocs >>= cmdDoc "names")
     $ ChannelCommand cmdChanNames noChannelTab
 
   , Command
       (pure "channelinfo")
       (pure ())
-      "\^BDescription:\^B\n\
-      \\n\
-      \    Show information about the current channel.\n\
-      \    Press ESC to exit the channel info window.\n\
-      \\n\
-      \    Information includes topic, creation time, URL, and modes.\n\
-      \\n\
-      \\^BSee also:\^B masks, mode, topic, users\n"
+      $(chatDocs >>= cmdDoc "channelinfo")
     $ ChannelCommand cmdChannelInfo noChannelTab
 
   , Command
       (pure "knock")
       (liftA2 (,) (simpleToken "channel") (remainingArg "message"))
-      "Request entry to an invite-only channel.\n"
+      $(chatDocs >>= cmdDoc "knock")
     $ NetworkCommand cmdKnock simpleNetworkTab
 
   , Command
       (pure "quote")
       (remainingArg "raw IRC command")
-      "Send a raw IRC command.\n"
+      $(chatDocs >>= cmdDoc "quote")
     $ NetworkCommand cmdQuote simpleNetworkTab
 
   , Command
       (pure "monitor")
       (extensionArg "[+-CLS]" monitorArgs)
-      "\^BSubcommands:\^B\n\
-      \\n\
-      \    /monitor + target[,target2]* - Add nicknames to monitor list\n\
-      \    /monitor - target[,target2]* - Remove nicknames to monitor list\n\
-      \    /monitor C                   - Clear monitor list\n\
-      \    /monitor L                   - Show monitor list\n\
-      \    /monitor S                   - Show status of nicknames on monitor list\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Monitor is a protocol for getting server-side notifications\n\
-      \    when users become online/offline.\n"
+      $(chatDocs >>= cmdDoc "monitor")
     $ NetworkCommand cmdMonitor simpleNetworkTab
 
-    ]
+  ]
 
 monitorArgs :: ClientState -> String -> Maybe (Args ClientState [String])
 monitorArgs _ str =

--- a/src/Client/Commands/Connection.hs
+++ b/src/Client/Commands/Connection.hs
@@ -29,37 +29,37 @@ connectionCommands = CommandSection "Connection commands"
   [ Command
       (pure "connect")
       (simpleToken "network")
-      $(netDocs >>= cmdDoc "connect")
+      $(netDocs `cmdDoc` "connect")
     $ ClientCommand cmdConnect tabConnect
 
   , Command
       (pure "reconnect")
       (pure ())
-      $(netDocs >>= cmdDoc "reconnect")
+      $(netDocs `cmdDoc` "reconnect")
     $ ClientCommand cmdReconnect noClientTab
 
   , Command
       (pure "disconnect")
       (pure ())
-      $(netDocs >>= cmdDoc "disconnect")
+      $(netDocs `cmdDoc` "disconnect")
     $ NetworkCommand cmdDisconnect noNetworkTab
 
   , Command
       (pure "quit")
       (remainingArg "reason")
-      $(netDocs >>= cmdDoc "quit")
+      $(netDocs `cmdDoc` "quit")
     $ NetworkCommand cmdQuit simpleNetworkTab
 
   , Command
       (pure "cert")
       (pure ())
-      $(netDocs >>= cmdDoc "cert")
+      $(netDocs `cmdDoc` "cert")
     $ NetworkCommand cmdCert noNetworkTab
 
   , Command
       (pure "umode")
       (remainingArg "modes")
-      $(netDocs >>= cmdDoc "umode")
+      $(netDocs `cmdDoc` "umode")
     $ NetworkCommand cmdUmode noNetworkTab
   ]
 

--- a/src/Client/Commands/Connection.hs
+++ b/src/Client/Commands/Connection.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Connection
 Description : Connection command implementations
@@ -10,6 +10,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Connection (connectionCommands) where
 
 import Client.Commands.Arguments.Spec ( remainingArg, simpleToken )
+import Client.Commands.Docs (netDocs, cmdDoc)
 import Client.Commands.TabCompletion
 import Client.Commands.Types
 import Client.Commands.WordCompletion ( plainWordCompleteMode )
@@ -28,45 +29,37 @@ connectionCommands = CommandSection "Connection commands"
   [ Command
       (pure "connect")
       (simpleToken "network")
-      "Connect to \^Bnetwork\^B by name.\n\
-      \\n\
-      \If no name is configured the hostname is the 'name'.\n"
+      $(netDocs >>= cmdDoc "connect")
     $ ClientCommand cmdConnect tabConnect
 
   , Command
       (pure "reconnect")
       (pure ())
-      "Reconnect to the current network.\n"
+      $(netDocs >>= cmdDoc "reconnect")
     $ ClientCommand cmdReconnect noClientTab
 
   , Command
       (pure "disconnect")
       (pure ())
-      "Immediately terminate the current network connection.\n\
-      \\n\
-      \See also: /quit /exit\n"
+      $(netDocs >>= cmdDoc "disconnect")
     $ NetworkCommand cmdDisconnect noNetworkTab
 
   , Command
       (pure "quit")
       (remainingArg "reason")
-      "Gracefully disconnect the current network connection.\n\
-      \\n\
-      \\^Breason\^B: optional quit reason\n\
-      \\n\
-      \See also: /disconnect /exit\n"
+      $(netDocs >>= cmdDoc "quit")
     $ NetworkCommand cmdQuit simpleNetworkTab
 
   , Command
       (pure "cert")
       (pure ())
-      "Show the TLS certificate for the current connection.\n"
+      $(netDocs >>= cmdDoc "cert")
     $ NetworkCommand cmdCert noNetworkTab
 
   , Command
       (pure "umode")
       (remainingArg "modes")
-      "Apply a user-mode change.\n"
+      $(netDocs >>= cmdDoc "umode")
     $ NetworkCommand cmdUmode noNetworkTab
   ]
 

--- a/src/Client/Commands/Docs.hs
+++ b/src/Client/Commands/Docs.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 
 {-|
 Module      : Client.Commands.Docs
@@ -22,37 +22,38 @@ module Client.Commands.Docs
   , windowDocs
   ) where
 
-import Language.Haskell.TH (Q, Exp)
 import Client.Docs (Docs, loadDoc, lookupDoc, makeHeader)
+import Language.Haskell.TH (Q, Exp)
+import Language.Haskell.TH.Syntax (lift)
 
-cmdDoc :: String -> Docs -> Q Exp
-cmdDoc key = lookupDoc (makeHeader "Description") ('/':key)
+cmdDoc :: Docs -> String -> Q Exp
+cmdDoc docs key = lookupDoc (makeHeader "Description") ('/':key) docs
 
 -- TODO: Replace each id with something that splits off the command name.
 
-chanopDocs :: Q Docs
-chanopDocs = loadDoc id "cmds_chanop"
+chanopDocs :: Docs
+chanopDocs = $(loadDoc id "cmds_chanop" >>= lift)
 
-chatDocs :: Q Docs
-chatDocs = loadDoc id "cmds_chat"
+chatDocs :: Docs
+chatDocs = $(loadDoc id "cmds_chat" >>= lift)
 
-clientDocs :: Q Docs
-clientDocs = loadDoc id "cmds_client"
+clientDocs :: Docs
+clientDocs = $(loadDoc id "cmds_client" >>= lift)
 
-integrationDocs :: Q Docs
-integrationDocs = loadDoc id "cmds_integration"
+integrationDocs :: Docs
+integrationDocs = $(loadDoc id "cmds_integration" >>= lift)
 
-netDocs :: Q Docs
-netDocs = loadDoc id "cmds_net"
+netDocs :: Docs
+netDocs = $(loadDoc id "cmds_net" >>= lift)
 
-operDocs :: Q Docs
-operDocs = loadDoc id "cmds_oper"
+operDocs :: Docs
+operDocs = $(loadDoc id "cmds_oper" >>= lift)
 
-queriesDocs :: Q Docs
-queriesDocs = loadDoc id "cmds_queries"
+queriesDocs :: Docs
+queriesDocs = $(loadDoc id "cmds_queries" >>= lift)
 
-togglesDocs :: Q Docs
-togglesDocs = loadDoc id "cmds_toggles"
+togglesDocs :: Docs
+togglesDocs = $(loadDoc id "cmds_toggles" >>= lift)
 
-windowDocs :: Q Docs
-windowDocs = loadDoc id "cmds_window"
+windowDocs :: Docs
+windowDocs = $(loadDoc id "cmds_window" >>= lift)

--- a/src/Client/Commands/Docs.hs
+++ b/src/Client/Commands/Docs.hs
@@ -1,0 +1,58 @@
+{-# Language OverloadedStrings #-}
+
+{-|
+Module      : Client.Commands.Docs
+Description : Command documentation
+Copyright   : (c) TheDaemoness 2023
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+This module contains definitions for all of glirc's command docs.
+-}
+module Client.Commands.Docs
+  ( cmdDoc
+  , chanopDocs
+  , chatDocs
+  , clientDocs
+  , integrationDocs
+  , netDocs
+  , operDocs
+  , queriesDocs
+  , togglesDocs
+  , windowDocs
+  ) where
+
+import Language.Haskell.TH (Q, Exp)
+import Client.Docs (Docs, loadDoc, lookupDoc, makeHeader)
+
+cmdDoc :: String -> Docs -> Q Exp
+cmdDoc key = lookupDoc (makeHeader "Description") ('/':key)
+
+-- TODO: Replace each id with something that splits off the command name.
+
+chanopDocs :: Q Docs
+chanopDocs = loadDoc id "cmds_chanop"
+
+chatDocs :: Q Docs
+chatDocs = loadDoc id "cmds_chat"
+
+clientDocs :: Q Docs
+clientDocs = loadDoc id "cmds_client"
+
+integrationDocs :: Q Docs
+integrationDocs = loadDoc id "cmds_integration"
+
+netDocs :: Q Docs
+netDocs = loadDoc id "cmds_net"
+
+operDocs :: Q Docs
+operDocs = loadDoc id "cmds_oper"
+
+queriesDocs :: Q Docs
+queriesDocs = loadDoc id "cmds_queries"
+
+togglesDocs :: Q Docs
+togglesDocs = loadDoc id "cmds_toggles"
+
+windowDocs :: Q Docs
+windowDocs = loadDoc id "cmds_window"

--- a/src/Client/Commands/Operator.hs
+++ b/src/Client/Commands/Operator.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Operator
 Description : Operator command implementations
@@ -10,6 +10,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Operator (operatorCommands) where
 
 import Client.Commands.Arguments.Spec (optionalArg, remainingArg, simpleToken)
+import Client.Commands.Docs (operDocs, cmdDoc)
 import Client.Commands.TabCompletion (noNetworkTab, simpleNetworkTab)
 import Client.Commands.Types
 import Client.State.Network (sendMsg)
@@ -25,152 +26,153 @@ operatorCommands = CommandSection "Network operator commands"
   [ Command
       (pure "oper")
       (liftA2 (,) (simpleToken "user") (simpleToken "password"))
-      "Authenticate as a server operator.\n"
+      $(operDocs >>= cmdDoc "oper")
     $ NetworkCommand cmdOper noNetworkTab
 
   , Command
       (pure "kill")
       (liftA2 (,) (simpleToken "client") (remainingArg "reason"))
-      "Kill a client connection to the server.\n"
+      $(operDocs >>= cmdDoc "kill")
     $ NetworkCommand cmdKill simpleNetworkTab
 
   , Command
       (pure "kline")
       (liftA3 (,,) (simpleToken "minutes") (simpleToken "user@host") (remainingArg "reason"))
-      "Ban a client from the server.\n"
+      $(operDocs >>= cmdDoc "kline")
     $ NetworkCommand cmdKline simpleNetworkTab
 
   , Command
       (pure "unkline")
       (liftA2 (,) (simpleToken "[user@]host") (optionalArg (simpleToken "[servername]")))
-      "Unban a client from the server.\n"
+      $(operDocs >>= cmdDoc "unkline")
     $ NetworkCommand cmdUnkline simpleNetworkTab
 
   , Command
       (pure "undline")
       (liftA2 (,) (simpleToken "host") (optionalArg (simpleToken "[servername]")))
-      "Unban a client from the server.\n"
+      $(operDocs >>= cmdDoc "undline")
     $ NetworkCommand cmdUndline simpleNetworkTab
 
   , Command
       (pure "unxline")
       (liftA2 (,) (simpleToken "gecos") (optionalArg (simpleToken "[servername]")))
-      "Unban a gecos from the server.\n"
+      $(operDocs >>= cmdDoc "unxline")
     $ NetworkCommand cmdUnxline simpleNetworkTab
 
   , Command
       (pure "unresv")
       (liftA2 (,) (simpleToken "channel|nick") (optionalArg (simpleToken "[servername]")))
-      "Unban a channel or nickname from the server.\n"
+      $(operDocs >>= cmdDoc "unresv")
     $ NetworkCommand cmdUnresv simpleNetworkTab
 
   , Command
       (pure "testline")
       (simpleToken "[[nick!]user@]host")
-      "Check matching I/K/D lines for a [[nick!]user@]host\n"
+      $(operDocs >>= cmdDoc "testline")
     $ NetworkCommand cmdTestline simpleNetworkTab
 
   , Command
       (pure "testkline")
       (simpleToken "[user@]host")
-      "Check matching K/D lines for a [user@]host\n"
+      $(operDocs >>= cmdDoc "testkline")
     $ NetworkCommand cmdTestkline simpleNetworkTab
 
   , Command
       (pure "testgecos")
       (simpleToken "gecos")
-      "Check matching X lines for a gecos\n"
+      $(operDocs >>= cmdDoc "testgecos")
     $ NetworkCommand cmdTestGecos simpleNetworkTab
 
   , Command
       (pure "testmask")
       (liftA2 (,) (simpleToken "[nick!]user@host") (remainingArg "[gecos]"))
-      "Test how many local and global clients match a mask.\n"
+      $(operDocs >>= cmdDoc "testmask")
     $ NetworkCommand cmdTestmask simpleNetworkTab
 
   , Command
       (pure "masktrace")
       (liftA2 (,) (simpleToken "[nick!]user@host") (remainingArg "[gecos]"))
-      "Outputs a list of local users matching the given masks.\n"
+      $(operDocs >>= cmdDoc "masktrace")
     $ NetworkCommand cmdMasktrace simpleNetworkTab
 
   , Command
       (pure "chantrace")
       (simpleToken "channel")
-      "Outputs a list of channel members in etrace format.\n"
+      $(operDocs >>= cmdDoc "chantrace")
     $ NetworkCommand cmdChantrace simpleNetworkTab
 
   , Command
       (pure "trace")
       (optionalArg (liftA2 (,) (simpleToken "[server|nick]") (optionalArg (simpleToken "[location]"))))
-      "Outputs a list users on a server.\n"
+      $(operDocs >>= cmdDoc "trace")
     $ NetworkCommand cmdTrace simpleNetworkTab
 
   , Command
       (pure "etrace")
       (optionalArg (simpleToken "[-full|-v4|-v6|nick]"))
-      "Outputs a list users on a server.\n"
+      $(operDocs >>= cmdDoc "etrace")
     $ NetworkCommand cmdEtrace simpleNetworkTab
 
   , Command
       (pure "map")
       (pure ())
-      "Display network map.\n"
+      $(operDocs >>= cmdDoc "map")
     $ NetworkCommand cmdMap simpleNetworkTab
 
   , Command
       (pure "sconnect")
       (liftA2 (,) (simpleToken "connect_to") (optionalArg (liftA2 (,) (simpleToken "[port]") (optionalArg (simpleToken "[remote]")))))
-      "Connect two servers together.\n"
+      $(operDocs >>= cmdDoc "sconnect")
     $ NetworkCommand cmdSconnect simpleNetworkTab
 
   , Command
       (pure "squit")
       (liftA2 (,) (simpleToken "server") (remainingArg "[reason]"))
-      "Split a server away from your side of the network.\n"
+      $(operDocs >>= cmdDoc "squit")
     $ NetworkCommand cmdSquit simpleNetworkTab
 
   , Command
       (pure "modload")
       (liftA2 (,) (simpleToken "[path/]module") (optionalArg (simpleToken "[remote]")))
-      "Load an IRCd module.\n"
+      $(operDocs >>= cmdDoc "modload")
     $ NetworkCommand cmdModload simpleNetworkTab
 
   , Command
       (pure "modunload")
       (liftA2 (,) (simpleToken "module") (optionalArg (simpleToken "[remote]")))
-      "Unload an IRCd module.\n"
+      $(operDocs >>= cmdDoc "modunload")
     $ NetworkCommand cmdModunload simpleNetworkTab
 
   , Command
       (pure "modlist")
       (optionalArg (liftA2 (,) (simpleToken "pattern") (optionalArg (simpleToken "[remote]"))))
-      "List loaded IRCd modules.\n"
+      $(operDocs >>= cmdDoc "modlist")
     $ NetworkCommand cmdModlist simpleNetworkTab
 
   , Command
       (pure "modrestart")
       (optionalArg (simpleToken "[server]"))
-      "Reload all IRCd modules.\n"
+      $(operDocs >>= cmdDoc "modrestart")
     $ NetworkCommand cmdModrestart simpleNetworkTab
 
   , Command
       (pure "modreload")
       (liftA2 (,) (simpleToken "module") (optionalArg (simpleToken "[remote]")))
-      "Reload an IRCd module.\n"
+      $(operDocs >>= cmdDoc "modreload")
     $ NetworkCommand cmdModreload simpleNetworkTab
 
   , Command
       (pure "grant")
       (liftA2 (,) (simpleToken "target") (simpleToken "privset"))
-      "Manually assign a privset to a user.\n"
+      $(operDocs >>= cmdDoc "grant")
     $ NetworkCommand cmdGrant simpleNetworkTab
 
   , Command
       (pure "privs")
       (optionalArg (simpleToken "[target]"))
-      "Check operator privileges of the target.\n"
+      $(operDocs >>= cmdDoc "privs")
     $ NetworkCommand cmdPrivs simpleNetworkTab
+
   ]
 
 cmdGrant :: NetworkCommand (String, String)

--- a/src/Client/Commands/Operator.hs
+++ b/src/Client/Commands/Operator.hs
@@ -26,151 +26,151 @@ operatorCommands = CommandSection "Network operator commands"
   [ Command
       (pure "oper")
       (liftA2 (,) (simpleToken "user") (simpleToken "password"))
-      $(operDocs >>= cmdDoc "oper")
+      $(operDocs `cmdDoc` "oper")
     $ NetworkCommand cmdOper noNetworkTab
 
   , Command
       (pure "kill")
       (liftA2 (,) (simpleToken "client") (remainingArg "reason"))
-      $(operDocs >>= cmdDoc "kill")
+      $(operDocs `cmdDoc` "kill")
     $ NetworkCommand cmdKill simpleNetworkTab
 
   , Command
       (pure "kline")
       (liftA3 (,,) (simpleToken "minutes") (simpleToken "user@host") (remainingArg "reason"))
-      $(operDocs >>= cmdDoc "kline")
+      $(operDocs `cmdDoc` "kline")
     $ NetworkCommand cmdKline simpleNetworkTab
 
   , Command
       (pure "unkline")
       (liftA2 (,) (simpleToken "[user@]host") (optionalArg (simpleToken "[servername]")))
-      $(operDocs >>= cmdDoc "unkline")
+      $(operDocs `cmdDoc` "unkline")
     $ NetworkCommand cmdUnkline simpleNetworkTab
 
   , Command
       (pure "undline")
       (liftA2 (,) (simpleToken "host") (optionalArg (simpleToken "[servername]")))
-      $(operDocs >>= cmdDoc "undline")
+      $(operDocs `cmdDoc` "undline")
     $ NetworkCommand cmdUndline simpleNetworkTab
 
   , Command
       (pure "unxline")
       (liftA2 (,) (simpleToken "gecos") (optionalArg (simpleToken "[servername]")))
-      $(operDocs >>= cmdDoc "unxline")
+      $(operDocs `cmdDoc` "unxline")
     $ NetworkCommand cmdUnxline simpleNetworkTab
 
   , Command
       (pure "unresv")
       (liftA2 (,) (simpleToken "channel|nick") (optionalArg (simpleToken "[servername]")))
-      $(operDocs >>= cmdDoc "unresv")
+      $(operDocs `cmdDoc` "unresv")
     $ NetworkCommand cmdUnresv simpleNetworkTab
 
   , Command
       (pure "testline")
       (simpleToken "[[nick!]user@]host")
-      $(operDocs >>= cmdDoc "testline")
+      $(operDocs `cmdDoc` "testline")
     $ NetworkCommand cmdTestline simpleNetworkTab
 
   , Command
       (pure "testkline")
       (simpleToken "[user@]host")
-      $(operDocs >>= cmdDoc "testkline")
+      $(operDocs `cmdDoc` "testkline")
     $ NetworkCommand cmdTestkline simpleNetworkTab
 
   , Command
       (pure "testgecos")
       (simpleToken "gecos")
-      $(operDocs >>= cmdDoc "testgecos")
+      $(operDocs `cmdDoc` "testgecos")
     $ NetworkCommand cmdTestGecos simpleNetworkTab
 
   , Command
       (pure "testmask")
       (liftA2 (,) (simpleToken "[nick!]user@host") (remainingArg "[gecos]"))
-      $(operDocs >>= cmdDoc "testmask")
+      $(operDocs `cmdDoc` "testmask")
     $ NetworkCommand cmdTestmask simpleNetworkTab
 
   , Command
       (pure "masktrace")
       (liftA2 (,) (simpleToken "[nick!]user@host") (remainingArg "[gecos]"))
-      $(operDocs >>= cmdDoc "masktrace")
+      $(operDocs `cmdDoc` "masktrace")
     $ NetworkCommand cmdMasktrace simpleNetworkTab
 
   , Command
       (pure "chantrace")
       (simpleToken "channel")
-      $(operDocs >>= cmdDoc "chantrace")
+      $(operDocs `cmdDoc` "chantrace")
     $ NetworkCommand cmdChantrace simpleNetworkTab
 
   , Command
       (pure "trace")
       (optionalArg (liftA2 (,) (simpleToken "[server|nick]") (optionalArg (simpleToken "[location]"))))
-      $(operDocs >>= cmdDoc "trace")
+      $(operDocs `cmdDoc` "trace")
     $ NetworkCommand cmdTrace simpleNetworkTab
 
   , Command
       (pure "etrace")
       (optionalArg (simpleToken "[-full|-v4|-v6|nick]"))
-      $(operDocs >>= cmdDoc "etrace")
+      $(operDocs `cmdDoc` "etrace")
     $ NetworkCommand cmdEtrace simpleNetworkTab
 
   , Command
       (pure "map")
       (pure ())
-      $(operDocs >>= cmdDoc "map")
+      $(operDocs `cmdDoc` "map")
     $ NetworkCommand cmdMap simpleNetworkTab
 
   , Command
       (pure "sconnect")
       (liftA2 (,) (simpleToken "connect_to") (optionalArg (liftA2 (,) (simpleToken "[port]") (optionalArg (simpleToken "[remote]")))))
-      $(operDocs >>= cmdDoc "sconnect")
+      $(operDocs `cmdDoc` "sconnect")
     $ NetworkCommand cmdSconnect simpleNetworkTab
 
   , Command
       (pure "squit")
       (liftA2 (,) (simpleToken "server") (remainingArg "[reason]"))
-      $(operDocs >>= cmdDoc "squit")
+      $(operDocs `cmdDoc` "squit")
     $ NetworkCommand cmdSquit simpleNetworkTab
 
   , Command
       (pure "modload")
       (liftA2 (,) (simpleToken "[path/]module") (optionalArg (simpleToken "[remote]")))
-      $(operDocs >>= cmdDoc "modload")
+      $(operDocs `cmdDoc` "modload")
     $ NetworkCommand cmdModload simpleNetworkTab
 
   , Command
       (pure "modunload")
       (liftA2 (,) (simpleToken "module") (optionalArg (simpleToken "[remote]")))
-      $(operDocs >>= cmdDoc "modunload")
+      $(operDocs `cmdDoc` "modunload")
     $ NetworkCommand cmdModunload simpleNetworkTab
 
   , Command
       (pure "modlist")
       (optionalArg (liftA2 (,) (simpleToken "pattern") (optionalArg (simpleToken "[remote]"))))
-      $(operDocs >>= cmdDoc "modlist")
+      $(operDocs `cmdDoc` "modlist")
     $ NetworkCommand cmdModlist simpleNetworkTab
 
   , Command
       (pure "modrestart")
       (optionalArg (simpleToken "[server]"))
-      $(operDocs >>= cmdDoc "modrestart")
+      $(operDocs `cmdDoc` "modrestart")
     $ NetworkCommand cmdModrestart simpleNetworkTab
 
   , Command
       (pure "modreload")
       (liftA2 (,) (simpleToken "module") (optionalArg (simpleToken "[remote]")))
-      $(operDocs >>= cmdDoc "modreload")
+      $(operDocs `cmdDoc` "modreload")
     $ NetworkCommand cmdModreload simpleNetworkTab
 
   , Command
       (pure "grant")
       (liftA2 (,) (simpleToken "target") (simpleToken "privset"))
-      $(operDocs >>= cmdDoc "grant")
+      $(operDocs `cmdDoc` "grant")
     $ NetworkCommand cmdGrant simpleNetworkTab
 
   , Command
       (pure "privs")
       (optionalArg (simpleToken "[target]"))
-      $(operDocs >>= cmdDoc "privs")
+      $(operDocs `cmdDoc` "privs")
     $ NetworkCommand cmdPrivs simpleNetworkTab
 
   ]

--- a/src/Client/Commands/Queries.hs
+++ b/src/Client/Commands/Queries.hs
@@ -32,97 +32,97 @@ queryCommands = CommandSection "Queries"
   [ Command
       (pure "who")
       (optionalArg (liftA2 (,) (simpleToken "[channel|nick|mask]") (optionalArg (simpleToken "[options]"))))
-      $(queriesDocs >>= cmdDoc "who")
+      $(queriesDocs `cmdDoc` "who")
     $ NetworkCommand cmdWho simpleNetworkTab
 
   , Command
       (pure "whois")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "whois")
+      $(queriesDocs `cmdDoc` "whois")
     $ NetworkCommand cmdWhois simpleNetworkTab
 
   , Command
       (pure "whowas")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "whowas")
+      $(queriesDocs `cmdDoc` "whowas")
     $ NetworkCommand cmdWhowas simpleNetworkTab
 
   , Command
       (pure "ison")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "ison")
+      $(queriesDocs `cmdDoc` "ison")
     $ NetworkCommand cmdIson   simpleNetworkTab
 
   , Command
       (pure "userhost")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "userhost")
+      $(queriesDocs `cmdDoc` "userhost")
     $ NetworkCommand cmdUserhost simpleNetworkTab
 
   , Command
       (pure "time")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "time")
+      $(queriesDocs `cmdDoc` "time")
     $ NetworkCommand cmdTime simpleNetworkTab
 
   , Command
       (pure "stats")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "stats")
+      $(queriesDocs `cmdDoc` "stats")
     $ NetworkCommand cmdStats simpleNetworkTab
 
   , Command
       (pure "lusers")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "lusers")
+      $(queriesDocs `cmdDoc` "lusers")
     $ NetworkCommand cmdLusers simpleNetworkTab
 
   , Command
       (pure "users")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "users")
+      $(queriesDocs `cmdDoc` "users")
     $ NetworkCommand cmdUsers simpleNetworkTab
 
   , Command
       (pure "motd")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "motd")
+      $(queriesDocs `cmdDoc` "motd")
     $ NetworkCommand cmdMotd simpleNetworkTab
 
   , Command
       (pure "admin")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "admin")
+      $(queriesDocs `cmdDoc` "admin")
     $ NetworkCommand cmdAdmin simpleNetworkTab
 
   , Command
       (pure "rules")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "rules")
+      $(queriesDocs `cmdDoc` "rules")
     $ NetworkCommand cmdRules simpleNetworkTab
 
   , Command
       (pure "info")
       (pure ())
-      $(queriesDocs >>= cmdDoc "info")
+      $(queriesDocs `cmdDoc` "info")
     $ NetworkCommand cmdInfo noNetworkTab
 
   , Command
       (pure "list")
       (optionalArg (extensionArg "[clientarg]" listArgs))
-      $(queriesDocs >>= cmdDoc "list")
+      $(queriesDocs `cmdDoc` "list")
     $ NetworkCommand cmdList simpleNetworkTab
 
   , Command
       (pure "links")
       (remainingArg "arguments")
-      $(queriesDocs >>= cmdDoc "links")
+      $(queriesDocs `cmdDoc` "links")
     $ NetworkCommand cmdLinks simpleNetworkTab
 
   , Command
       (pure "version")
       (optionalArg (simpleToken "[servername]"))
-      $(queriesDocs >>= cmdDoc "version")
+      $(queriesDocs `cmdDoc` "version")
     $ NetworkCommand cmdVersion simpleNetworkTab
 
   ]

--- a/src/Client/Commands/Queries.hs
+++ b/src/Client/Commands/Queries.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE ViewPatterns #-}
 {-|
@@ -12,6 +12,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Queries (queryCommands) where
 
 import Client.Commands.Arguments.Spec (optionalArg, remainingArg, simpleToken, extensionArg, Args)
+import Client.Commands.Docs (queriesDocs, cmdDoc)
 import Client.Commands.TabCompletion (noNetworkTab, simpleNetworkTab)
 import Client.Commands.Types (commandSuccess, commandSuccessUpdateCS, Command(Command), CommandImpl(NetworkCommand), CommandSection(CommandSection), NetworkCommand)
 import Client.State (changeSubfocus, ClientState)
@@ -31,115 +32,97 @@ queryCommands = CommandSection "Queries"
   [ Command
       (pure "who")
       (optionalArg (liftA2 (,) (simpleToken "[channel|nick|mask]") (optionalArg (simpleToken "[options]"))))
-      "Send WHO query to server with given arguments, or just show the who view.\n"
+      $(queriesDocs >>= cmdDoc "who")
     $ NetworkCommand cmdWho simpleNetworkTab
 
   , Command
       (pure "whois")
       (remainingArg "arguments")
-      "Send WHOIS query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "whois")
     $ NetworkCommand cmdWhois simpleNetworkTab
 
   , Command
       (pure "whowas")
       (remainingArg "arguments")
-      "Send WHOWAS query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "whowas")
     $ NetworkCommand cmdWhowas simpleNetworkTab
 
   , Command
       (pure "ison")
       (remainingArg "arguments")
-      "Send ISON query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "ison")
     $ NetworkCommand cmdIson   simpleNetworkTab
 
   , Command
       (pure "userhost")
       (remainingArg "arguments")
-      "Send USERHOST query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "userhost")
     $ NetworkCommand cmdUserhost simpleNetworkTab
 
   , Command
       (pure "time")
       (optionalArg (simpleToken "[servername]"))
-      "Send TIME query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "time")
     $ NetworkCommand cmdTime simpleNetworkTab
 
   , Command
       (pure "stats")
       (remainingArg "arguments")
-      "Send STATS query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "stats")
     $ NetworkCommand cmdStats simpleNetworkTab
 
   , Command
       (pure "lusers")
       (optionalArg (simpleToken "[servername]"))
-      "Send LUSERS query to a given server.\n"
+      $(queriesDocs >>= cmdDoc "lusers")
     $ NetworkCommand cmdLusers simpleNetworkTab
 
   , Command
       (pure "users")
       (optionalArg (simpleToken "[servername]"))
-      "Send USERS query to a given server.\n"
+      $(queriesDocs >>= cmdDoc "users")
     $ NetworkCommand cmdUsers simpleNetworkTab
 
   , Command
-      (pure "motd") (optionalArg (simpleToken "[servername]"))
-      "Send MOTD query to server.\n"
+      (pure "motd")
+      (optionalArg (simpleToken "[servername]"))
+      $(queriesDocs >>= cmdDoc "motd")
     $ NetworkCommand cmdMotd simpleNetworkTab
 
   , Command
-      (pure "admin") (optionalArg (simpleToken "[servername]"))
-      "Send ADMIN query to server.\n"
+      (pure "admin")
+      (optionalArg (simpleToken "[servername]"))
+      $(queriesDocs >>= cmdDoc "admin")
     $ NetworkCommand cmdAdmin simpleNetworkTab
 
   , Command
-      (pure "rules") (optionalArg (simpleToken "[servername]"))
-      "Send RULES query to server.\n"
+      (pure "rules")
+      (optionalArg (simpleToken "[servername]"))
+      $(queriesDocs >>= cmdDoc "rules")
     $ NetworkCommand cmdRules simpleNetworkTab
 
   , Command
-      (pure "info") (pure ())
-      "Send INFO query to server.\n"
+      (pure "info")
+      (pure ())
+      $(queriesDocs >>= cmdDoc "info")
     $ NetworkCommand cmdInfo noNetworkTab
 
   , Command
       (pure "list")
       (optionalArg (extensionArg "[clientarg]" listArgs))
-      "\^BParameters:\^B\n\
-      \\n\
-      \    clientarg: An optionally-comma-separated list of\n\
-      \               flags for controlling the list.\n\
-      \        ~: Always refresh the list.\n\
-      \        >n: Show only channels with more than \^Bn\^B users.\n\
-      \        <n: Show only channels with less than \^Bn\^B users.\n\
-      \\n\
-      \    serverarg: The ELIST argument to send to the server.\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    View the list of public channels on the server.\n\
-      \\n\
-      \    Sends a LIST query and caches the result;\n\
-      \    on larger networks on slower connections,\n\
-      \    this may take a while to complete.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /list\n\
-      \    /list >100\n\
-      \    /list ~ <20\n\
-      \    /list , *-ops"
+      $(queriesDocs >>= cmdDoc "list")
     $ NetworkCommand cmdList simpleNetworkTab
 
   , Command
       (pure "links")
       (remainingArg "arguments")
-      "Send LINKS query to server with given arguments.\n"
+      $(queriesDocs >>= cmdDoc "links")
     $ NetworkCommand cmdLinks simpleNetworkTab
 
   , Command
-      (pure "version") (optionalArg (simpleToken "[servername]"))
-      "Send VERSION query to server.\n"
+      (pure "version")
+      (optionalArg (simpleToken "[servername]"))
+      $(queriesDocs >>= cmdDoc "version")
     $ NetworkCommand cmdVersion simpleNetworkTab
 
   ]

--- a/src/Client/Commands/Toggles.hs
+++ b/src/Client/Commands/Toggles.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Toggles
 Description : View modality command implementations
@@ -9,6 +9,7 @@ Maintainer  : emertens@gmail.com
 
 module Client.Commands.Toggles (togglesCommands) where
 
+import Client.Commands.Docs (togglesDocs, cmdDoc)
 import Client.Commands.TabCompletion (noClientTab)
 import Client.Commands.Types
 import Client.Configuration (EditMode(SingleLineEditor, MultiLineEditor), LayoutMode(OneColumn, TwoColumn))
@@ -21,43 +22,43 @@ togglesCommands = CommandSection "View toggles"
   [ Command
       (pure "toggle-detail")
       (pure ())
-      "Toggle detailed message view.\n"
+      $(togglesDocs >>= cmdDoc "toggle-detail")
     $ ClientCommand cmdToggleDetail noClientTab
 
   , Command
       (pure "toggle-activity-bar")
       (pure ())
-      "Toggle detailed detailed activity information in status bar.\n"
+      $(togglesDocs >>= cmdDoc "toggle-activity-bar")
     $ ClientCommand cmdToggleActivityBar noClientTab
 
   , Command
       (pure "toggle-show-ping")
       (pure ())
-      "Toggle visibility of ping round-trip time.\n"
+      $(togglesDocs >>= cmdDoc "toggle-show-ping")
     $ ClientCommand cmdToggleShowPing noClientTab
 
   , Command
       (pure "toggle-metadata")
       (pure ())
-      "Toggle visibility of metadata in chat windows.\n"
+      $(togglesDocs >>= cmdDoc "toggle-metadata")
     $ ClientCommand cmdToggleMetadata noClientTab
 
   , Command
       (pure "toggle-layout")
       (pure ())
-      "Toggle multi-window layout mode.\n"
+      $(togglesDocs >>= cmdDoc "toggle-layout")
     $ ClientCommand cmdToggleLayout noClientTab
 
   , Command
       (pure "toggle-editor")
       (pure ())
-      "Toggle between single-line and multi-line editor mode.\n"
+      $(togglesDocs >>= cmdDoc "toggle-editor")
     $ ClientCommand cmdToggleEditor noClientTab
 
   , Command
       (pure "toggle-edit-lock")
       (pure ())
-      "Toggle editor lock mode. When editor is locked pressing Enter is disabled.\n"
+      $(togglesDocs >>= cmdDoc "toggle-edit-lock")
     $ ClientCommand cmdToggleEditLock noClientTab
   ]
 

--- a/src/Client/Commands/Toggles.hs
+++ b/src/Client/Commands/Toggles.hs
@@ -22,43 +22,43 @@ togglesCommands = CommandSection "View toggles"
   [ Command
       (pure "toggle-detail")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-detail")
+      $(togglesDocs `cmdDoc` "toggle-detail")
     $ ClientCommand cmdToggleDetail noClientTab
 
   , Command
       (pure "toggle-activity-bar")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-activity-bar")
+      $(togglesDocs `cmdDoc` "toggle-activity-bar")
     $ ClientCommand cmdToggleActivityBar noClientTab
 
   , Command
       (pure "toggle-show-ping")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-show-ping")
+      $(togglesDocs `cmdDoc` "toggle-show-ping")
     $ ClientCommand cmdToggleShowPing noClientTab
 
   , Command
       (pure "toggle-metadata")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-metadata")
+      $(togglesDocs `cmdDoc` "toggle-metadata")
     $ ClientCommand cmdToggleMetadata noClientTab
 
   , Command
       (pure "toggle-layout")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-layout")
+      $(togglesDocs `cmdDoc` "toggle-layout")
     $ ClientCommand cmdToggleLayout noClientTab
 
   , Command
       (pure "toggle-editor")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-editor")
+      $(togglesDocs `cmdDoc` "toggle-editor")
     $ ClientCommand cmdToggleEditor noClientTab
 
   , Command
       (pure "toggle-edit-lock")
       (pure ())
-      $(togglesDocs >>= cmdDoc "toggle-edit-lock")
+      $(togglesDocs `cmdDoc` "toggle-edit-lock")
     $ ClientCommand cmdToggleEditLock noClientTab
   ]
 

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -42,79 +42,79 @@ windowCommands = CommandSection "Window management"
   [ Command
       (pure "focus")
       (liftA2 (,) (simpleToken "network") (optionalArg (simpleToken "[target]")))
-      $(windowDocs >>= cmdDoc "focus")
+      $(windowDocs `cmdDoc` "focus")
     $ ClientCommand cmdFocus tabFocus
 
   , Command
       ("c" :| ["channel"])
       (simpleToken "focus")
-      $(windowDocs >>= cmdDoc "channel")
+      $(windowDocs `cmdDoc` "channel")
     $ ClientCommand cmdChannel tabChannel
 
   , Command
       (pure "clear")
       (optionalArg (liftA2 (,) (simpleToken "[network]") (optionalArg (simpleToken "[channel]"))))
-      $(windowDocs >>= cmdDoc "clear")
+      $(windowDocs `cmdDoc` "clear")
     $ ClientCommand cmdClear tabFocus
 
   , Command
       (pure "windows")
       (optionalArg (simpleToken "[kind]"))
-      $(windowDocs >>= cmdDoc "windows")
+      $(windowDocs `cmdDoc` "windows")
     $ ClientCommand cmdWindows tabWindows
 
   , Command
       (pure "splits")
       (remainingArg "focuses")
-      $(windowDocs >>= cmdDoc "splits")
+      $(windowDocs `cmdDoc` "splits")
     $ ClientCommand cmdSplits tabSplits
 
   , Command
       (pure "splits+")
       (remainingArg "focuses")
-      $(windowDocs >>= cmdDoc "splits")
+      $(windowDocs `cmdDoc` "splits")
     $ ClientCommand cmdSplitsAdd tabSplits
 
   , Command
       (pure "splits-")
       (remainingArg "focuses")
-      $(windowDocs >>= cmdDoc "splits")
+      $(windowDocs `cmdDoc` "splits")
     $ ClientCommand cmdSplitsDel tabActiveSplits
 
   , Command
       (pure "ignore")
       (remainingArg "masks")
-      $(windowDocs >>= cmdDoc "ignore")
+      $(windowDocs `cmdDoc` "ignore")
     $ ClientCommand cmdIgnore tabIgnore
 
   , Command
       (pure "grep")
       (remainingArg "regular-expression")
-      $(windowDocs >>= cmdDoc "grep")
+      $(windowDocs `cmdDoc` "grep")
     $ ClientCommand cmdGrep simpleClientTab
 
   , Command
       (pure "dump")
       (simpleToken "filename")
-      $(windowDocs >>= cmdDoc "dump")
+      $(windowDocs `cmdDoc` "dump")
     $ ClientCommand cmdDump simpleClientTab
 
   , Command
       (pure "mentions")
       (pure ())
-      $(windowDocs >>= cmdDoc "mentions")
+      $(windowDocs `cmdDoc` "mentions")
     $ ClientCommand cmdMentions noClientTab
 
   , Command
       (pure "setwindow")
       (simpleToken ("hide|show" ++ concatMap ('|':) activityFilterStrings))
-      $(windowDocs >>= cmdDoc "setwindow")
+      $(windowDocs `cmdDoc` "setwindow")
     $ ClientCommand cmdSetWindow tabSetWindow
 
   , Command
       (pure "setname")
       (optionalArg (simpleToken "[letter]"))
-      $(windowDocs >>= cmdDoc "setname")
+      $(windowDocs `cmdDoc` "setname")
     $ ClientCommand cmdSetWindowName noClientTab
 
   ]

--- a/src/Client/Commands/Window.hs
+++ b/src/Client/Commands/Window.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language OverloadedStrings, TemplateHaskell #-}
 {-|
 Module      : Client.Commands.Window
 Description : Window command implementations
@@ -10,6 +10,7 @@ Maintainer  : emertens@gmail.com
 module Client.Commands.Window (windowCommands, parseFocus) where
 
 import Client.Commands.Arguments.Spec
+import Client.Commands.Docs (windowDocs, cmdDoc)
 import Client.Commands.TabCompletion
 import Client.Commands.Types
 import Client.Commands.WordCompletion (plainWordCompleteMode)
@@ -41,216 +42,79 @@ windowCommands = CommandSection "Window management"
   [ Command
       (pure "focus")
       (liftA2 (,) (simpleToken "network") (optionalArg (simpleToken "[target]")))
-      "Change the focused window.\n\
-      \\n\
-      \When only \^Bnetwork\^B is specified this switches to the network status window.\n\
-      \When \^Bnetwork\^B and \^Btarget\^B are specified this switches to that chat window.\n\
-      \\n\
-      \Nickname and channels can be specified in the \^Btarget\^B parameter.\n\
-      \See also: /query (aliased /c /channel) to switch to a target on the current network.\n"
+      $(windowDocs >>= cmdDoc "focus")
     $ ClientCommand cmdFocus tabFocus
 
   , Command
       ("c" :| ["channel"])
       (simpleToken "focus")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    focuses: Focus name\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    This command sets the current window focus. When\n\
-      \    no network is specified, the current network will\n\
-      \    be used.\n\
-      \\n\
-      \    Client:  *\n\
-      \    Network: \^_network\^_:\n\
-      \    Channel: \^_#channel\^_\n\
-      \    Channel: \^_network\^_:\^_#channel\^_\n\
-      \    User:    \^_nick\^_\n\
-      \    User:    \^_network\^_:\^_nick\^_\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /c fn:#haskell\n\
-      \    /c #haskell\n\
-      \    /c fn:\n\
-      \    /c *:\n\
-      \\n\
-      \\^BSee also:\^B focus\n"
+      $(windowDocs >>= cmdDoc "channel")
     $ ClientCommand cmdChannel tabChannel
 
   , Command
       (pure "clear")
       (optionalArg (liftA2 (,) (simpleToken "[network]") (optionalArg (simpleToken "[channel]"))))
-      "Clear a window.\n\
-      \\n\
-      \If no arguments are provided the current window is cleared.\n\
-      \If \^Bnetwork\^B is provided the that network window is cleared.\n\
-      \If \^Bnetwork\^B and \^Bchannel\^B are provided that chat window is cleared.\n\
-      \If \^Bnetwork\^B is provided and \^Bchannel\^B is \^B*\^O all windows for that network are cleared.\n\
-      \\n\
-      \If a window is cleared and no longer active that window will be removed from the client.\n"
+      $(windowDocs >>= cmdDoc "clear")
     $ ClientCommand cmdClear tabFocus
 
   , Command
       (pure "windows")
       (optionalArg (simpleToken "[kind]"))
-      "Show a list of all windows with an optional argument to limit the kinds of windows listed.\n\
-      \\n\
-      \\^Bkind\^O: one of \^Bnetworks\^O, \^Bchannels\^O, \^Busers\^O\n\
-      \\n"
+      $(windowDocs >>= cmdDoc "windows")
     $ ClientCommand cmdWindows tabWindows
 
   , Command
       (pure "splits")
       (remainingArg "focuses")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    focuses: List of focus names\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    This command sents the set of focuses that will always\n\
-      \    be visible, even when unfocused. When the client is focused\n\
-      \    to an active network, the network can be omitted when\n\
-      \    specifying a focus. If no focuses are listed, they will\n\
-      \    all be cleared.\n\
-      \\n\
-      \    Client:  *\n\
-      \    Network: \^_network\^_:\n\
-      \    Channel: \^_#channel\^_\n\
-      \    Channel: \^_network\^_:\^_#channel\^_\n\
-      \    User:    \^_nick\^_\n\
-      \    User:    \^_network\^_:\^_nick\^_\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /splits * fn:#haskell fn:chanserv\n\
-      \    /splits #haskell #haskell-lens nickserv\n\
-      \    /splits\n\
-      \\n\
-      \\^BSee also:\^B splits+, splits-\n"
+      $(windowDocs >>= cmdDoc "splits")
     $ ClientCommand cmdSplits tabSplits
 
   , Command
       (pure "splits+")
       (remainingArg "focuses")
-      "Add windows to the splits list. Omit the list of focuses to add the\
-      \ current window.\n\
-      \\n\
-      \\^Bfocuses\^B: space delimited list of focus names.\n\
-      \\n\
-      \Client:  *\n\
-      \Network: \^BNETWORK\^B\n\
-      \Channel: \^BNETWORK\^B:\^B#CHANNEL\^B\n\
-      \User:    \^BNETWORK\^B:\^BNICK\^B\n\
-      \\n\
-      \If the network part is omitted, the current network will be used.\n"
+      $(windowDocs >>= cmdDoc "splits")
     $ ClientCommand cmdSplitsAdd tabSplits
 
   , Command
       (pure "splits-")
       (remainingArg "focuses")
-      "Remove windows from the splits list. Omit the list of focuses to\
-      \ remove the current window.\n\
-      \\n\
-      \\^Bfocuses\^B: space delimited list of focus names.\n\
-      \\n\
-      \Client:  *\n\
-      \Network: \^BNETWORK\^B\n\
-      \Channel: \^BNETWORK\^B:\^B#CHANNEL\^B\n\
-      \User:    \^BNETWORK\^B:\^BNICK\^B\n\
-      \\n\
-      \If the network part is omitted, the current network will be used.\n"
+      $(windowDocs >>= cmdDoc "splits")
     $ ClientCommand cmdSplitsDel tabActiveSplits
 
   , Command
       (pure "ignore")
       (remainingArg "masks")
-      "\^BParameters:\^B\n\
-      \\n\
-      \    masks: List of masks\n\
-      \\n\
-      \\^BDescription:\^B\n\
-      \\n\
-      \    Toggle the soft-ignore on each of the space-delimited given\n\
-      \    nicknames. Ignores can use \^B*\^B (many) and \^B?\^B (one) wildcards.\n\
-      \    Masks can be of the form: nick[[!user]@host]\n\
-      \    Masks use a case-insensitive comparison.\n\
-      \\n\
-      \    If no masks are specified the current ignore list is displayed.\n\
-      \\n\
-      \\^BExamples:\^B\n\
-      \\n\
-      \    /ignore\n\
-      \    /ignore nick1 nick2 nick3\n\
-      \    /ignore nick@host\n\
-      \    /ignore nick!user@host\n\
-      \    /ignore *@host\n\
-      \    /ignore *!baduser@*\n"
+      $(windowDocs >>= cmdDoc "ignore")
     $ ClientCommand cmdIgnore tabIgnore
 
   , Command
       (pure "grep")
       (remainingArg "regular-expression")
-      "Set the persistent regular expression.\n\
-      \\n\
-      \\^BFlags:\^B\n\
-      \    -A n Show n messages after match\n\
-      \    -B n Show n messages before match\n\
-      \    -C n Show n messages before and after match\n\
-      \    -F   Use plain-text match instead of regular expression\n\
-      \    -i   Case insensitive match\n\
-      \    -v   Invert pattern match\n\
-      \    -m n Limit results to n matches\n\
-      \    --   Stop processing flags\n\
-      \\n\
-      \Clear the regular expression by calling this without an argument.\n\
-      \\n\
-      \\^B/grep\^O is case-sensitive.\n"
+      $(windowDocs >>= cmdDoc "grep")
     $ ClientCommand cmdGrep simpleClientTab
 
   , Command
       (pure "dump")
       (simpleToken "filename")
-      "Dump current buffer to file.\n"
+      $(windowDocs >>= cmdDoc "dump")
     $ ClientCommand cmdDump simpleClientTab
 
   , Command
       (pure "mentions")
       (pure ())
-      "Show a list of all message that were highlighted as important.\n\
-      \\n\
-      \When using \^B/grep\^B the important messages are those matching\n\
-      \the regular expression instead.\n"
+      $(windowDocs >>= cmdDoc "mentions")
     $ ClientCommand cmdMentions noClientTab
 
   , Command
       (pure "setwindow")
       (simpleToken ("hide|show" ++ concatMap ('|':) activityFilterStrings))
-      "Set window property.\n\
-      \\n\
-      \\^Bsilent\^B / \^Bquieter\^B / \^Bquiet\^B / \^Bimponly\^B / \^Bloud\^B / \^Blouder\^B\n\
-      \    Changes the importance of normal and important messages:\n\
-      \      \^Blouder\^B: Upgrades normal to important.\n\
-      \      \^Bloud\^B: Uses default values.\n\
-      \      \^Bimponly\^B: Downgrades normal to boring.\n\
-      \      \^Bquiet\^B: Downgrades important to normal.\n\
-      \      \^Bquieter\^B: Downgrades both one step.\n\
-      \      \^Bsilent\^B: Downgrades both to boring.\n\
-      \\n\
-      \\^Bshow\^B / \^Bhide\^B\n\
-      \    Toggles if window appears in window command shortcuts.\n"
+      $(windowDocs >>= cmdDoc "setwindow")
     $ ClientCommand cmdSetWindow tabSetWindow
 
   , Command
       (pure "setname")
       (optionalArg (simpleToken "[letter]"))
-      "Set window shortcut letter. If no letter is provided the next available\n\
-      \letter will automatically be assigned.\n\
-      \\n\
-      \Available letters are configured in the 'window-names' configuration setting.\n"
+      $(windowDocs >>= cmdDoc "setname")
     $ ClientCommand cmdSetWindowName noClientTab
 
   ]

--- a/src/Client/Commands/ZNC.hs
+++ b/src/Client/Commands/ZNC.hs
@@ -1,4 +1,4 @@
-{-# Language OverloadedStrings #-}
+{-# Language TemplateHaskell, OverloadedStrings #-}
 {-|
 Module      : Client.Commands.ZNC
 Description : ZNC command implementations
@@ -11,6 +11,7 @@ module Client.Commands.ZNC (zncCommands) where
 
 import Control.Applicative ((<|>), empty, liftA2)
 import Client.Commands.Arguments.Spec (optionalArg, remainingArg, simpleToken)
+import Client.Commands.Docs (integrationDocs, cmdDoc)
 import Client.Commands.TabCompletion (noNetworkTab, simpleNetworkTab)
 import Client.Commands.Types
 import Client.State.Network (sendMsg)
@@ -26,26 +27,13 @@ zncCommands = CommandSection "ZNC Support"
   [ Command
       (pure "znc")
       (remainingArg "arguments")
-      "Send command directly to ZNC.\n\
-      \\n\
-      \The advantage of this over /msg is that responses are not broadcast to call clients.\n"
+      $(integrationDocs >>= cmdDoc "znc")
     $ NetworkCommand cmdZnc simpleNetworkTab
 
   , Command
       (pure "znc-playback")
       (optionalArg (liftA2 (,) (simpleToken "[time]") (optionalArg (simpleToken "[date]"))))
-      "Request playback from the ZNC 'playback' module.\n\
-      \\n\
-      \\^Btime\^B determines the time to playback since.\n\
-      \\^Bdate\^B determines the date to playback since.\n\
-      \\n\
-      \When both \^Btime\^B and \^Bdate\^B are omitted, all playback is requested.\n\
-      \When both \^Bdate\^B is omitted it is defaulted the most recent date in the past that makes sense.\n\
-      \\n\
-      \Time format: HOURS:MINUTES (example: 7:00)\n\
-      \Date format: YEAR-MONTH-DAY (example: 2016-06-16)\n\
-      \\n\
-      \Note that the playback module is not installed in ZNC by default!\n"
+      $(integrationDocs >>= cmdDoc "znc-playback")
     $ NetworkCommand cmdZncPlayback noNetworkTab
 
   ]

--- a/src/Client/Commands/ZNC.hs
+++ b/src/Client/Commands/ZNC.hs
@@ -27,13 +27,13 @@ zncCommands = CommandSection "ZNC Support"
   [ Command
       (pure "znc")
       (remainingArg "arguments")
-      $(integrationDocs >>= cmdDoc "znc")
+      $(integrationDocs `cmdDoc` "znc")
     $ NetworkCommand cmdZnc simpleNetworkTab
 
   , Command
       (pure "znc-playback")
       (optionalArg (liftA2 (,) (simpleToken "[time]") (optionalArg (simpleToken "[date]"))))
-      $(integrationDocs >>= cmdDoc "znc-playback")
+      $(integrationDocs `cmdDoc` "znc-playback")
     $ NetworkCommand cmdZncPlayback noNetworkTab
 
   ]

--- a/src/Client/Docs.hs
+++ b/src/Client/Docs.hs
@@ -1,0 +1,104 @@
+{-# Language OverloadedStrings #-}
+
+{-|
+Module      : Client.Docs
+Description : Compile-time documentation injection
+Copyright   : (c) TheDaemoness 2023
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+This module adds the requisite functions to load and parse
+a subset of AsciiDoc and embed it using Template Haskell.
+-}
+module Client.Docs
+  ( Docs
+  , loadDoc
+  , lookupDoc
+  , makeHeader
+  ) where
+
+import           Prelude hiding (readFile)
+
+import           Control.Applicative ((<|>))
+import qualified Data.Attoparsec.Text as Parse
+import           Data.ByteString (readFile)
+import           Data.Char (isSpace)
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LText
+import           Data.Text.Encoding (decodeUtf8)
+import           Language.Haskell.TH (Exp, Q, runIO)
+import           Language.Haskell.TH.Syntax (lift)
+
+type Docs = HashMap String LText.Text
+
+data Line
+  = Discarded
+  | Section Text
+  | Subsection Text
+  | Contents LText.Text
+
+makeHeader :: LText.Text -> LText.Text
+makeHeader header = LText.append "\^B" (LText.append header ":\^B\n")
+
+loadDoc :: (String -> String) -> FilePath -> Q Docs
+loadDoc keymod path = runIO (readFile splicePath >>= renderDoc)
+  where
+    splicePath = "doc/" ++ path ++ ".adoc"
+    renderDoc doc = case Parse.parseOnly lineParser $ decodeUtf8 doc of
+      Right docs -> return $ buildDocs keymod docs
+      Left errorMsg -> fail ("Parser failed on `" ++ splicePath ++ "`: " ++ errorMsg)
+
+lookupDoc :: LText.Text -> String -> Docs -> Q Exp
+lookupDoc header name docs =
+  case HashMap.lookup name docs of
+    Just doc -> lift $ LText.toStrict $ LText.append header doc
+    Nothing -> fail failMsg
+  where
+    failMsg = "No docs for `" ++ name ++ "` (have " ++ show (HashMap.keys docs) ++ ")"
+
+buildDocs :: (String -> String) -> [Line] -> Docs
+buildDocs keymod parsedLines = docs
+  where
+    folded = foldl (addLine keymod) (HashMap.empty, "", LText.empty) parsedLines
+    (docs, _, _) = addLine keymod folded (Section "")
+
+addLine :: (String -> String) -> (Docs, Text, LText.Text) -> Line -> (Docs, Text, LText.Text)
+addLine _      (docs, section, text)      Discarded    = (docs, section, text)
+addLine _      (docs, "", _)              (Section s') = (docs, s', LText.empty)
+addLine _      (docs, "", text)           _            = (docs, "", text)
+addLine keymod (docs, section, text) line              = case line of
+  -- TODO: Actually parse formatting.
+  -- Do it here rather than in the contents parser
+  -- so that we can handle state for things like source code blocks.
+  -- Also replace the 3-tuple with a proper record type when doing stateful parsing.
+  Contents text'   -> (docs, section, append' text')
+  Subsection text' -> (docs, section, append' (makeHeader (LText.fromStrict text')))
+  Section s'       -> (HashMap.insert (keymod $ Text.unpack section) text docs, s', LText.empty)
+  where
+    append' = LText.append text
+
+lineParser :: Parse.Parser [Line]
+lineParser = Parse.many1' (sectionParser <|> contentsParser) <* Parse.endOfInput
+  where
+    sectionParser = Parse.char '=' >> (sectionL2Parser <|> sectionL3Parser <|> return Discarded)
+      where
+        sectionL2Parser = do
+          _ <- Parse.string "= "
+          name <- Parse.takeWhile1 (not . isSpace)
+          eolParser
+          return (Section name)
+        sectionL3Parser = do
+          _ <- Parse.takeWhile1 (== '=')
+          Parse.skipWhile (== ' ')
+          chars <- Parse.manyTill Parse.anyChar eolParser
+          return (Subsection $ Text.pack chars)
+    contentsParser = do
+      chars <- Parse.manyTill Parse.anyChar eolParser
+      return $ Contents $ LText.fromChunks ["  ", Text.pack chars, "\n"]
+    eolParser = do
+      spaces <- Parse.takeWhile (== ' ')
+      _ <- if Text.null spaces then pure '+' else Parse.option '+' (Parse.char '+')
+      Parse.endOfLine


### PR DESCRIPTION
The goal of this branch is to extract the command documentation from glirc's source code into separate files, then make use of Template Haskell to add it back in. This allows viewing up-to-date documentation for glirc without running it, and makes editing said docs easier.

This branch contains a minimum viable implementation. It supports an extremely limited subset of AsciiDoc, but documents every command in glirc. Further work can be done on supporting more of AsciiDoc as-needed, as well as refining the documentation itself.