### PR TITLE
Try to support matterbridge color nicks

### DIFF
--- a/src/Client/Hook/Matterbridge.hs
+++ b/src/Client/Hook/Matterbridge.hs
@@ -54,9 +54,9 @@ remap nick chanfilter ircmsg =
 
 remap' :: MbMsg -> UserInfo -> Identifier -> Text -> MessageResult
 remap' mbmsg ui chan msg =
-  case msg =~ ("^<([^>]+)> (.*)$"::Text) of
-    [_,nick,msg']:_ -> RemapMessage (newmsg mbmsg (fakeUser nick ui) chan msg')
-    _               -> PassMessage
+  case msg =~ ("^(\ETX[0-9][0-9])?<([^>]+)> \SI?(.*)$"::Text) of
+    [_,_,nick,msg']:_ -> RemapMessage (newmsg mbmsg (fakeUser nick ui) chan msg')
+    _                 -> PassMessage
 
 newmsg :: MbMsg -> Source -> Identifier -> Text -> IrcMsg
 newmsg Msg src chan msg = Privmsg src chan msg


### PR DESCRIPTION
#haskell turned on the color nicks for the matterbridge, so this attempts to parse out the color codes. It just throws out the color codes from the bridge and keeps the nickname remapping.