### PR TITLE
Add /in command and supporting changes

### DIFF
--- a/doc/cmds_client.adoc
+++ b/doc/cmds_client.adoc
@@ -12,6 +12,17 @@ Reload the client configuration file.
 If `filename` is provided it will be used to reload.
 Otherwise the previously loaded configuration file will be reloaded.
 
+== /in
+
+Execute a command on a window other than the current one.
+
+`focus` is the name of a window as would be used with the `channel` command.
+
+`command` is any command that runs in a specific context
+(i.e. that does not have a context of "client").
+
+See also: channel
+
 == /extension
 
 Run a command provided by an extension.
@@ -85,4 +96,3 @@ Show command documentation.
 
 When `command` is omitted, a list of all commands and macros is shown.
 When `command` is specified, detailed help for that command is shown.
-

--- a/doc/cmds_client.adoc
+++ b/doc/cmds_client.adoc
@@ -18,10 +18,15 @@ Execute a command on a window other than the current one.
 
 `focus` is the name of a window as would be used with the `channel` command.
 
-`command` is any command that runs in a specific context
-(i.e. that does not have a context of "client").
+`command` is the name of a command or macro followed by its arguments.
+Macro expansions will be resolved as if `focus` was the current focus.
 
 See also: channel
+
+=== Examples
+
+`+/in libera: list+` +
+`+/in #glirc setwindow louder+`
 
 == /extension
 

--- a/doc/cmds_queries.adoc
+++ b/doc/cmds_queries.adoc
@@ -65,10 +65,10 @@ Sends a LIST query and caches the result;
 on larger networks, this may take several seconds to complete.
 The view may be exited while loading.
 
-`clientarg` is an optionally-comma-separated list of options.
+`clientopts` is an optionally-comma-separated list of options.
 A single comma may be used to denote an empty list.
 
-`serverarg` is sent as-is to the server.
+`elist` is sent as-is to the server.
 It is generally used as the ELIST parameter to LIST.
 glirc does not validate this parameter against the ELIST ISUPPORT token.
 
@@ -83,7 +83,7 @@ glirc does not validate this parameter against the ELIST ISUPPORT token.
 `+/list+`          - List public channels.
 `+/list >99+`      - List public channels with at least 100 users.
 `+/list >50<1000+` - List public channels with between 51 and 999 users.
-`+/list ~ <20+`    - List public channels with fewer than 20 users. 
+`+/list ~ <20+`    - List public channels with fewer than 20 users.
 `+/list , *-ops+`  - List public channels whose names end with "-ops".
 
 == /links

--- a/src/Client/Commands.hs
+++ b/src/Client/Commands.hs
@@ -26,7 +26,7 @@ module Client.Commands
   ) where
 
 import Client.Commands.Arguments.Parser (parse)
-import Client.Commands.Arguments.Spec (optionalArg, optionalNumberArg, remainingArg, simpleToken)
+import Client.Commands.Arguments.Spec (optionalArg, optionalNumberArg, remainingArg, simpleToken, extensionArg, mapArgEnv, Args)
 import Client.Commands.Docs (clientDocs, cmdDoc)
 import Client.Commands.Exec
 import Client.Commands.Interpolation (resolveMacroExpansions, Macro(Macro), MacroSpec(MacroSpec))
@@ -43,6 +43,7 @@ import Control.Exception (displayException, try)
 import Control.Lens
 import Control.Monad (guard, foldM)
 import Data.Foldable (foldl', toList)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time (getZonedTime)
@@ -62,7 +63,7 @@ import Client.Commands.Queries (queryCommands)
 import Client.Commands.TabCompletion
 import Client.Commands.Toggles (togglesCommands)
 import Client.Commands.Types
-import Client.Commands.Window (windowCommands)
+import Client.Commands.Window (windowCommands, parseFocus, focusNames)
 import Client.Commands.ZNC (zncCommands)
 
 -- | Interpret the given chat message or command. Leading @/@ indicates a
@@ -78,7 +79,7 @@ execute str st =
   case dropWhile (' '==) str of
     []          -> commandFailure st
     '/':command -> executeUserCommand Nothing command st'
-    _           -> executeChat str st'
+    _           -> executeChat (view clientFocus st') str st'
 
 -- | Execute command provided by user, resolve aliases if necessary.
 --
@@ -90,7 +91,21 @@ executeUserCommand ::
   String           {- ^ command            -} ->
   ClientState      {- ^ client state       -} ->
   IO CommandResult {- ^ command result     -}
-executeUserCommand discoTime command st = do
+executeUserCommand = executeUserCommandIn Nothing
+
+-- | Execute command provided by user, resolve aliases if necessary,
+-- optionally in the provided focus instead of the current one.
+--
+-- The last disconnection time is stored in text form and is available
+-- for substitutions in macros. It is only provided when running startup
+-- commands during a reconnect event.
+executeUserCommandIn ::
+  Maybe Focus      {- ^ focus override     -} ->
+  Maybe Text       {- ^ disconnection time -} ->
+  String           {- ^ command            -} ->
+  ClientState      {- ^ client state       -} ->
+  IO CommandResult {- ^ command result     -}
+executeUserCommandIn focusOverride discoTime command st = do
   let key = Text.takeWhile (/=' ') (Text.pack command)
       rest = dropWhile (==' ') (dropWhile (/=' ') command)
 
@@ -99,7 +114,7 @@ executeUserCommand discoTime command st = do
       case doExpansion spec cmdExs rest of
         Nothing   -> commandFailureMsg "macro expansions failed" st
         Just cmds -> process cmds st
-    _ -> executeCommand Nothing command st
+    _ -> executeCommand Nothing focusOverride command st
   where
     doExpansion spec cmdExs rest =
       do args <- parse st spec rest
@@ -110,11 +125,9 @@ executeUserCommand discoTime command st = do
     expandInt :: [a] -> Integer -> Maybe a
     expandInt args i = preview (ix (fromInteger i)) args
 
-
-
     process [] st0 = commandSuccess st0
     process (c:cs) st0 =
-      do res <- executeCommand Nothing (Text.unpack c) st0
+      do res <- executeCommand Nothing focusOverride (Text.unpack c) st0
          case res of
            CommandSuccess st1 -> process cs st1
            CommandFailure st1 -> process cs st1 -- ?
@@ -146,64 +159,103 @@ tabCompletion ::
   IO CommandResult {- ^ command result -}
 tabCompletion isReversed st =
   case dropWhile (' ' ==) $ snd $ clientLine st of
-    '/':command -> executeCommand (Just isReversed) command st
+    '/':command -> executeCommand (Just isReversed) Nothing command st
     _           -> nickTabCompletion isReversed st
 
+data ContextFreeCommand = forall a. ContextFreeCommand
+  { cfCmdCtx  :: ArgsContext
+  , cfCmdArgs :: Args ArgsContext a
+  , cfCmdIsClientCmd :: Bool 
+  , cfCmdExec :: ClientState -> a -> IO CommandResult
+  , cfCmdTab  :: Bool -> ClientState -> String -> IO CommandResult
+  }
+
+executeContextFreeCommand :: ContextFreeCommand -> Maybe Bool -> String -> IO CommandResult
+executeContextFreeCommand ContextFreeCommand{cfCmdCtx=ctx, cfCmdArgs=spec, cfCmdExec=exec, cfCmdTab=tab} tabComplete args =
+  case tabComplete of
+    Just isReversed -> tab isReversed (argsContextSt ctx) args
+    Nothing ->
+      case parse ctx spec args of
+        Nothing -> commandFailureMsg "bad command arguments" (argsContextSt ctx)
+        Just arg -> exec (argsContextSt ctx) arg
+
+cfCmdAsArgs :: ContextFreeCommand -> Args ArgsContext (ClientState -> IO CommandResult)
+cfCmdAsArgs ContextFreeCommand{cfCmdArgs=spec, cfCmdExec=exec} = fmap (flip exec) spec
+
+-- | Look up a command by name and return a @ContextFreeCommand@.
+prepareCommand :: Focus -> String -> ClientState -> Either Text ContextFreeCommand
+prepareCommand focus cmd st =
+  case recognize (Text.toLower $ Text.pack cmd) commands of
+    Exact Command{cmdImplementation=impl, cmdArgumentSpec=argSpec} ->
+      let
+        cfCmd exec tab isClient = Right $ ContextFreeCommand
+          { cfCmdCtx=ArgsContext {argsContextSt=st, argsContextFocus=focus}
+          , cfCmdArgs=argSpec
+          , cfCmdExec=exec
+          , cfCmdTab=tab
+          , cfCmdIsClientCmd=isClient
+          }
+      in case impl of
+        ClientCommand exec tab ->
+          cfCmd exec tab True
+
+        WindowCommand exec tab ->
+          cfCmd (exec focus) (`tab` focus) False
+
+        NetworkCommand exec tab
+          | Just network <- focusNetwork focus
+          , Just cs      <- preview (clientConnection network) st ->
+              cfCmd (exec cs) (`tab` cs) False
+          | otherwise -> Left "command requires focused network"
+
+        MaybeChatCommand exec tab
+          | Just cs <- maybeNetwork ->
+              cfCmd (exec maybeChat cs) (\x -> tab x maybeChat cs) False
+          | otherwise -> Left "command requires focused network"
+          where
+            maybeChat
+              | ChannelFocus _ channel <- focus = Just channel
+              | otherwise = Nothing
+            maybeNetwork = do
+              network <- focusNetwork focus
+              preview (clientConnection network) st
+
+        ChannelCommand exec tab
+          | ChannelFocus network channelId <- focus
+          , Just cs <- preview (clientConnection network) st
+          , isChannelIdentifier cs channelId ->
+              cfCmd (exec channelId cs) (\x -> tab x channelId cs) False
+          | otherwise -> Left "command requires focused channel"
+
+        ChatCommand exec tab
+          | ChannelFocus network channelId <- focus
+          , Just cs <- preview (clientConnection network) st ->
+              cfCmd (exec channelId cs) (\x -> tab x channelId cs) False
+          | otherwise -> Left "command requires focused chat window"
+
+    _ -> Left "unknown command"
 
 -- | Parse and execute the given command. When the first argument is Nothing
 -- the command is executed, otherwise the first argument is the cursor
 -- position for tab-completion
 executeCommand ::
   Maybe Bool       {- ^ tab-completion direction -} ->
+  Maybe Focus      {- ^ focus override           -} ->
   String           {- ^ command                  -} ->
   ClientState      {- ^ client state             -} ->
   IO CommandResult {- ^ command result           -}
 
-executeCommand (Just isReversed) _ st
+executeCommand (Just isReversed) _ _ st
   | Just st' <- commandNameCompletion isReversed st = commandSuccess st'
 
-executeCommand tabCompleteReversed str st =
-  let (cmd, rest) = break (==' ') str
-      cmdTxt      = Text.toLower (Text.pack cmd)
-
-      finish spec exec tab =
-        case tabCompleteReversed of
-          Just isReversed -> tab isReversed st rest
-          Nothing ->
-            case parse st spec rest of
-              Nothing -> commandFailureMsg "bad command arguments" st
-              Just arg -> exec st arg
-  in
-  case recognize cmdTxt commands of
-
-    Exact Command{cmdImplementation=impl, cmdArgumentSpec=argSpec} ->
-      case impl of
-        ClientCommand exec tab ->
-          finish argSpec exec tab
-
-        NetworkCommand exec tab
-          | Just network <- views clientFocus focusNetwork st
-          , Just cs      <- preview (clientConnection network) st ->
-              finish argSpec (exec cs) (\x -> tab x cs)
-          | otherwise -> commandFailureMsg "command requires focused network" st
-
-        ChannelCommand exec tab
-          | ChannelFocus network channelId <- view clientFocus st
-          , Just cs <- preview (clientConnection network) st
-          , isChannelIdentifier cs channelId ->
-              finish argSpec (exec channelId cs) (\x -> tab x channelId cs)
-          | otherwise -> commandFailureMsg "command requires focused channel" st
-
-        ChatCommand exec tab
-          | ChannelFocus network channelId <- view clientFocus st
-          , Just cs <- preview (clientConnection network) st ->
-              finish argSpec (exec channelId cs) (\x -> tab x channelId cs)
-          | otherwise -> commandFailureMsg "command requires focused chat window" st
-
-    _ -> case tabCompleteReversed of
-           Just isReversed -> nickTabCompletion isReversed st
-           Nothing         -> commandFailureMsg "unknown command" st
-
+executeCommand tabComplete focusOverride str st =
+  let (cmd, args) = break (==' ') str
+      focus       = fromMaybe (view clientFocus st) focusOverride
+  in case prepareCommand focus cmd st of
+    Right cfCmd -> executeContextFreeCommand cfCmd tabComplete args
+    Left errmsg -> case tabComplete of
+      Just isReversed -> nickTabCompletion isReversed st
+      Nothing         -> commandFailureMsg errmsg st
 
 -- | Expands each alias to have its own copy of the command callbacks
 expandAliases :: [Command] -> [(Text,Command)]
@@ -236,6 +288,12 @@ commandsList =
       (optionalArg (simpleToken "[filename]"))
       $(clientDocs `cmdDoc` "reload")
     $ ClientCommand cmdReload tabReload
+
+  , Command
+      (pure "in")
+      (extensionArg "focus command" inArgs)
+      $(clientDocs `cmdDoc` "in")
+    $ ClientCommand cmdIn tabIn
 
   , Command
       (pure "extension")
@@ -480,3 +538,23 @@ openUrl (UrlOpener opener args) url st =
      case res of
        Left e  -> commandFailureMsg (Text.pack (displayException (e :: IOError))) st
        Right{} -> commandSuccess st
+
+inArgs :: ArgsContext -> String -> Maybe (Args ArgsContext (ClientState -> IO CommandResult))
+inArgs ArgsContext{argsContextFocus=focus} focusOverride =
+  fmap (\f -> mapArgEnv (changeArgsFocus f) $ extensionArg "command" inArgsCmd) parsedFocus
+  where
+    parsedFocus = parseFocus (focusNetwork focus) focusOverride
+    changeArgsFocus focus' argsContext = argsContext {argsContextFocus=focus'}
+    filterCfCmd (Right v@ContextFreeCommand{cfCmdIsClientCmd=False}) = Just v
+    filterCfCmd _ = Nothing
+    inArgsCmd :: ArgsContext -> String -> Maybe (Args ArgsContext (ClientState -> IO CommandResult))
+    inArgsCmd ArgsContext{argsContextFocus=focus', argsContextSt=st'} cmdName =
+      cfCmdAsArgs <$> (filterCfCmd $ prepareCommand focus' cmdName st')
+
+-- | Implementation of @/in@.
+cmdIn :: ClientCommand (ClientState -> IO CommandResult)
+cmdIn st fn = fn st -- All the magic is in the Args parser.
+
+tabIn :: Bool -> ClientCommand String
+tabIn isReversed st _ = -- TOOD: Command completion. This right here is just tabChannel.
+  simpleTabCompletion plainWordCompleteMode [] (focusNames st) isReversed st

--- a/src/Client/Commands/Arguments/Parser.hs
+++ b/src/Client/Commands/Arguments/Parser.hs
@@ -43,6 +43,7 @@ parseArg env spec =
       do t <- token
          subspec <- lift (parseFormat env t)
          parseArgs env subspec
+    MapEnv f inner -> parseArgs (f env) inner
 
 argumentString :: ArgumentShape -> Parser String
 argumentString TokenArgument     = token

--- a/src/Client/Commands/Arguments/Renderer.hs
+++ b/src/Client/Commands/Arguments/Renderer.hs
@@ -98,6 +98,8 @@ renderArg pal r placeholders spec = putState $
          else
            return (draw rest)
 
+    MapEnv f inner -> getState $ renderArgs pal (f r) placeholders inner
+
 token :: String -> ((String, String), String)
 token xs =
   let (lead, xs1) = span  (' '==) xs

--- a/src/Client/Commands/Arguments/Spec.hs
+++ b/src/Client/Commands/Arguments/Spec.hs
@@ -19,6 +19,7 @@ module Client.Commands.Arguments.Spec
   , optionalNumberArg
   , extensionArg
   , tokenArg
+  , mapArgEnv
 
   , ArgumentShape(..)
   , Arg(..)
@@ -38,6 +39,7 @@ data Arg :: Type -> Type -> Type where
   Argument  :: ArgumentShape -> String -> (r -> String -> Maybe a) -> Arg r a
   Optional  :: Args r a -> Arg r (Maybe a)
   Extension :: String -> (r -> String -> Maybe (Args r a)) -> Arg r a
+  MapEnv    :: (r -> s) -> Args s a -> Arg r a
 
 tokenArg :: String -> (r -> String -> Maybe a) -> Args r a
 tokenArg name parser = liftAp (Argument TokenArgument name parser)
@@ -59,6 +61,9 @@ numberArg = tokenArg "number" (\_ -> readMaybe)
 
 optionalNumberArg :: Args r (Maybe Int)
 optionalNumberArg = optionalArg (tokenArg "[number]" (\_ -> readMaybe))
+
+mapArgEnv :: (r -> s) -> Args s a -> Args r a
+mapArgEnv f = liftAp . MapEnv f
 
 tokenList ::
   [String] {- ^ required names -} ->

--- a/src/Client/Commands/Channel.hs
+++ b/src/Client/Commands/Channel.hs
@@ -128,7 +128,7 @@ cmdMasks channel cs st rest =
            unless (connecting || listLoaded)
              (sendMsg cs (ircMode channel [Text.singleton mode]))
 
-           commandSuccess (changeSubfocus (FocusMasks mode) st)
+           commandSuccess (changeSubfocus (FocusMasks (view csNetwork cs) channel mode) st)
 
     _ -> commandFailureMsg "unknown mask mode" st
 

--- a/src/Client/Commands/Channel.hs
+++ b/src/Client/Commands/Channel.hs
@@ -41,7 +41,7 @@ channelCommands = CommandSection "IRC channel management"
       (pure "mode")
       (fromMaybe [] <$> optionalArg (extensionArg "[modes]" modeParamArgs))
       $(chanopDocs `cmdDoc` "mode")
-    $ NetworkCommand cmdMode tabMode
+    $ MaybeChatCommand cmdMode tabMode
 
   , Command
       (pure "masks")
@@ -155,22 +155,22 @@ tabTopic _ channelId cs st rest
 
   | otherwise = commandFailure st
 
-cmdMode :: NetworkCommand [String]
-cmdMode cs st xs = modeCommand (Text.pack <$> xs) cs st
+cmdMode :: MaybeChatCommand [String]
+cmdMode chan cs st xs = modeCommand chan (Text.pack <$> xs) cs st
 
 modeCommand ::
-  [Text] {- mode parameters -} ->
-  NetworkState                 ->
-  ClientState                  ->
+  Maybe Identifier {- channel -} ->
+  [Text] {- mode parameters -}   ->
+  NetworkState                   ->
+  ClientState                    ->
   IO CommandResult
-modeCommand modes cs st =
-  case view clientFocus st of
-
-    NetworkFocus _ ->
+modeCommand maybeChan modes cs st =
+  case maybeChan of
+    Nothing ->
       do sendMsg cs (ircMode (view csNick cs) modes)
          commandSuccess st
 
-    ChannelFocus _ chan ->
+    Just chan ->
       case modes of
         [] -> success False [[]]
         flags:params ->
@@ -195,13 +195,10 @@ modeCommand modes cs st =
                       else cs <$ traverse_ (sendMsg cs) cmds
              commandSuccessUpdateCS cs' st
 
-    _ -> commandFailure st
-
-tabMode :: Bool -> NetworkCommand String
-tabMode isReversed cs st rest =
-  case view clientFocus st of
-
-    ChannelFocus _ channel
+tabMode :: Bool -> MaybeChatCommand String
+tabMode isReversed maybeChan cs st rest =
+  case maybeChan of
+    Just channel
       | flags:params     <- Text.words (Text.pack rest)
       , Just parsedModes <- splitModes (view csModeTypes cs) flags params
       , let parsedModesWithParams =
@@ -215,9 +212,9 @@ tabMode isReversed cs st rest =
   where
     paramIndex = length $ words $ uncurry take $ clientLine st
 
-modeParamArgs :: ClientState -> String -> Maybe (Args ClientState [String])
-modeParamArgs st str =
-  case view clientFocus st of
+modeParamArgs :: ArgsContext -> String -> Maybe (Args ArgsContext [String])
+modeParamArgs ArgsContext{argsContextSt=st, argsContextFocus=focus} str =
+  case focus of
     Unfocused      -> Nothing
     NetworkFocus _ -> Just (pure [str])
     ChannelFocus net _ ->

--- a/src/Client/Commands/Chat.hs
+++ b/src/Client/Commands/Chat.hs
@@ -159,10 +159,12 @@ cmdMonitor cs st args =
      commandSuccess st
 
 cmdChanNames :: ChannelCommand ()
-cmdChanNames _ _ st _ = commandSuccess (changeSubfocus FocusUsers st)
+cmdChanNames chan cs st _ = commandSuccess (changeSubfocus subfocus st)
+  where subfocus = FocusUsers (view csNetwork cs) chan
 
 cmdChannelInfo :: ChannelCommand ()
-cmdChannelInfo _ _ st _ = commandSuccess (changeSubfocus FocusInfo st)
+cmdChannelInfo chan cs st _ = commandSuccess (changeSubfocus subfocus st)
+  where subfocus = FocusInfo (view csNetwork cs) chan
 
 cmdKnock :: NetworkCommand (String, String)
 cmdKnock cs st (chan,message) =

--- a/src/Client/Commands/Queries.hs
+++ b/src/Client/Commands/Queries.hs
@@ -11,7 +11,7 @@ Maintainer  : emertens@gmail.com
 
 module Client.Commands.Queries (queryCommands) where
 
-import Client.Commands.Arguments.Spec (optionalArg, remainingArg, simpleToken, extensionArg, Args)
+import Client.Commands.Arguments.Spec (optionalArg, remainingArg, simpleToken, extensionArg, Args, tokenArg)
 import Client.Commands.Docs (queriesDocs, cmdDoc)
 import Client.Commands.TabCompletion (noNetworkTab, simpleNetworkTab)
 import Client.Commands.Types (commandSuccess, commandSuccessUpdateCS, Command(Command), CommandImpl(NetworkCommand), CommandSection(CommandSection), NetworkCommand)
@@ -109,7 +109,7 @@ queryCommands = CommandSection "Queries"
 
   , Command
       (pure "list")
-      (optionalArg (extensionArg "[clientarg]" listArgs))
+      (optionalArg (liftA2 (,) (tokenArg "[clientopts]" (const lsaParse)) (optionalArg (simpleToken "[elist]"))))
       $(queriesDocs `cmdDoc` "list")
     $ NetworkCommand cmdList simpleNetworkTab
 
@@ -139,34 +139,28 @@ cmdVersion cs st mbservername =
                                 Nothing -> ""
      commandSuccess st
 
-cmdList :: NetworkCommand (Maybe ListArgs)
+cmdList :: NetworkCommand (Maybe (ListArgs, Maybe String))
 cmdList cs st rest =
     do
-      let lsa = fromMaybe lsaDefault rest
+      let (lsa, maybeElist) = fromMaybe (lsaDefault, Nothing) rest
       let connecting = has (csPingStatus . _PingConnecting) cs
-      let elist = Just (Text.pack (fromMaybe "" (_lsaElist lsa)))
+      let elist = Just (Text.pack (fromMaybe "" maybeElist))
       let cached = elist == view (csChannelList . clsElist) cs
-      let sendM = sendMsg cs (ircList (Text.pack <$> maybeToList (_lsaElist lsa)))
+      let sendM = sendMsg cs (ircList (Text.pack <$> maybeToList maybeElist))
       unless (connecting || (cached && not (_lsaRefresh lsa))) sendM
       let cs' = set (csChannelList . clsElist) elist cs 
       let subfocus = FocusChanList (_lsaMin lsa) (_lsaMax lsa)
       commandSuccessUpdateCS cs' (changeSubfocus subfocus st)
 
-listArgs :: ClientState -> String -> Maybe (Args ClientState ListArgs)
-listArgs _ = fmap (withElist (optionalArg (simpleToken "[serverarg]"))) . lsaParse
-    where withElist arg a = fmap (\s -> a { _lsaElist = s }) arg
-
 data ListArgs = ListArgs
-  { _lsaElist   :: Maybe String
-  , _lsaRefresh :: Bool
+  { _lsaRefresh :: Bool
   , _lsaMin     :: Maybe Int
   , _lsaMax     :: Maybe Int
   }
 
 lsaDefault :: ListArgs
 lsaDefault = ListArgs
-  { _lsaElist = Nothing
-  , _lsaRefresh = False
+  { _lsaRefresh = False
   , _lsaMin = Nothing
   , _lsaMax = Nothing
   }

--- a/src/Client/EventLoop/Network.hs
+++ b/src/Client/EventLoop/Network.hs
@@ -152,7 +152,7 @@ processConnectCmd now cs st0 cmdTxt =
              Text.pack . formatTime defaultTimeLocale "%H:%M:%S"
                <$> utcToLocalZonedTime t
      let failureCase e = recordError now (view csNetwork cs) ("Bad connect-cmd: " <> e)
-     case resolveMacroExpansions (commandExpansion dc st0) (const Nothing) cmdTxt of
+     case resolveMacroExpansions (commandExpansion Nothing dc st0) (const Nothing) cmdTxt of
        Nothing -> return $! failureCase "Unable to expand connect command" st0
        Just cmdTxt' ->
          do res <- executeUserCommand dc (Text.unpack cmdTxt') st0

--- a/src/Client/Image/StatusLine.hs
+++ b/src/Client/Image/StatusLine.hs
@@ -22,7 +22,7 @@ import Client.Image.PackedImage
 import Client.Image.Palette
 import Client.State
 import Client.State.Channel (chanModes, chanUsers)
-import Client.State.Focus (actualFocus, focusNetwork, Focus(..), Subfocus(..), WindowsFilter(..))
+import Client.State.Focus (focusNetwork, Focus(..), Subfocus(..), WindowsFilter(..))
 import Client.State.Network
 import Client.State.Window
 import Control.Lens (view, orOf, preview, views, _Just, Ixed(ix))
@@ -31,18 +31,19 @@ import Data.Map.Strict qualified as Map
 import qualified Data.HashMap.Strict as HashMap
 import Data.Maybe (mapMaybe, maybeToList)
 import Data.Text (Text)
-import Data.Text qualified as Text
+import qualified Data.Text as Text
 import Data.Text.Lazy qualified as LText
 import Graphics.Vty.Attributes (Attr, defAttr, bold, withForeColor, withStyle, red)
 import Graphics.Vty.Image qualified as Vty
-import Irc.Identifier (idText)
+import Irc.Identifier (idText, mkId)
 import Numeric (showFFloat)
+import Client.WhoReply (whoQuery)
 
 clientTitle :: ClientState -> String
 clientTitle st
   = map cleanChar
   $ LText.unpack
-  $ "glirc - " <> imageText (viewFocusLabel st (view clientSubfocus st) (view clientFocus st))
+  $ "glirc - " <> imageText (currentViewImage False st (view clientSubfocus st) (view clientFocus st))
 
 bar :: Image'
 bar = char (withStyle defAttr bold) '─'
@@ -56,12 +57,13 @@ statusLineImage ::
 statusLineImage w st =
   makeLines w (common : activity ++ errorImgs)
   where
+    focus = (view clientFocus st)
     common = Vty.horizCat $
       myNickImage st :
       map unpackImage
-      [ focusImage (view clientFocus st) st
+      [ infoBubble $ currentViewImage True st (view clientSubfocus st) focus
       , detailImage st
-      , nometaImage (view clientFocus st) st
+      , nometaImage focus st
       , scrollImage st
       , filterImage st
       , lockImage st
@@ -103,9 +105,8 @@ minorStatusLineImage ::
 minorStatusLineImage focus subfocus w showHideMeta st =
   content <> mconcat (replicate fillSize bar)
   where
-    content = focusImage focus st <>
-              if showHideMeta then nometaImage focus st else mempty
-
+    nometaImage' = if showHideMeta then nometaImage focus st else mempty
+    content = infoBubble $ (currentViewImage True st subfocus focus <> nometaImage')
     fillSize = max 0 (w - imageWidth content)
 
 
@@ -244,7 +245,7 @@ activityBarImages st
                   $ unpackImage bar Vty.<|>
                     Vty.char defAttr '[' Vty.<|>
                     jumpLabel Vty.<|>
-                    focusLabel Vty.<|>
+                    unpackImage (focusLabel False st focus) Vty.<|>
                     Vty.char defAttr ':' Vty.<|>
                     Vty.string attr (show n) Vty.<|>
                     Vty.char defAttr ']'
@@ -259,11 +260,6 @@ activityBarImages st
         attr = case view winMention w of
                  WLImportant -> view palMention pal
                  _           -> view palActivity pal
-        focusLabel =
-          unpackImage $ case focus of
-            Unfocused           -> text' (view palLabel pal) (Text.pack "*")
-            NetworkFocus net    -> text' (view palLabel pal) (cleanText net)
-            ChannelFocus _ chan -> coloredIdentifier pal NormalIdentifier HashMap.empty chan
 
 
 -- | Pack a list of images into a single image spanning possibly many lines.
@@ -319,46 +315,29 @@ myNickImage st =
               | otherwise                = " " <>
                 modesImage (view palModes pal) (view palSnomask netpal) ('+':view csSnomask cs)
 
-focusImage :: Focus -> ClientState -> Image'
-focusImage focus st =
-  infoBubble $
-  case preview (clientWindows . ix focus' . winName . _Just) st of
-    Nothing -> label
-    Just n  -> char (view palWindowName pal) n <> ":" <> label
-  where
-    !pal     = clientPalette st
-    subfocus = view clientSubfocus st
-    focus'   = actualFocus subfocus focus
-    label    = viewFocusLabel st subfocus focus'
-
 parens :: Attr -> Vty.Image -> Vty.Image
 parens attr i = Vty.char attr '(' Vty.<|> i Vty.<|> Vty.char attr ')'
 
-viewFocusLabel :: ClientState -> Subfocus -> Focus -> Image'
-viewFocusLabel st subfocus focus =
+focusLabel :: Bool -> ClientState -> Focus -> Image'
+focusLabel showFull st focus =
   let
     !pal = clientPalette st
     netpal = clientNetworkPalette st
-    !subfocusLabel = case viewSubfocusLabel pal subfocus of
-      Just sfl -> " " <> sfl
-      Nothing -> mempty
   in case focus of
     Unfocused ->
-      char (view palError pal) '*' <> subfocusLabel
+      char (view palError pal) '*'
     NetworkFocus network ->
-      text' (view palLabel pal) (cleanText network) <> subfocusLabel
+      text' (view palLabel pal) (cleanText network)
     ChannelFocus network channel ->
       text' (view palLabel pal) (cleanText network) <>
       char defAttr ':' <>
       string (view palSigil pal) (cleanChar <$> sigils) <>
       coloredIdentifier pal NormalIdentifier HashMap.empty channel <>
-      subfocusLabel <> channelModes
-
+      channelModes
       where
         (sigils, channelModes) =
           case preview (clientConnection network) st of
-            Nothing -> ("", mempty)
-            Just cs ->
+            Just cs | showFull ->
                ( let nick = view csNick cs in
                  view (csChannels . ix channel . chanUsers . ix nick) cs
 
@@ -367,33 +346,41 @@ viewFocusLabel st subfocus focus =
                         " " <> modesImage (view palModes pal) (view palCModes netpal) ('+':Map.keys modeMap)
                     _ -> mempty
                )
+            _ -> ("", mempty)
 
-viewSubfocusLabel :: Palette -> Subfocus -> Maybe Image'
-viewSubfocusLabel pal subfocus =
+currentViewImage :: Bool -> ClientState -> Subfocus -> Focus -> Image'
+currentViewImage showFull st subfocus focus =
   case subfocus of
-    FocusMessages       -> Nothing
-    FocusWindows filt   -> Just $ string (view palLabel pal) "windows" <>
-                                opt (windowFilterName filt)
-    FocusInfo _ _       -> Just $ string (view palLabel pal) "info"
-    FocusUsers _ _      -> Just $ string (view palLabel pal) "users"
-    FocusMentions       -> Just $ string (view palLabel pal) "mentions"
-    FocusPalette        -> Just $ string (view palLabel pal) "palette"
-    FocusDigraphs       -> Just $ string (view palLabel pal) "digraphs"
-    FocusKeyMap         -> Just $ string (view palLabel pal) "keymap"
-    FocusHelp mb        -> Just $ string (view palLabel pal) "help" <> opt mb
-    FocusIgnoreList     -> Just $ string (view palLabel pal) "ignores"
-    FocusRtsStats       -> Just $ string (view palLabel pal) "rtsstats"
-    FocusCert{}         -> Just $ string (view palLabel pal) "cert"
-    FocusChanList _ _ _ -> Just $ string (view palLabel pal) "channels"
-    FocusWho _          -> Just $ string (view palLabel pal) "who"
-    FocusMasks _ _ m    -> Just $ mconcat
-      [ string (view palLabel pal) "masks"
-      , char defAttr ':'
-      , char (view palLabel pal) m
-      ]
+    FocusMessages         -> windowName <> focusLabel showFull st focus
+    FocusWindows filt     -> string defAttr "windows" <> opt (windowFilterName filt)
+    FocusInfo net chan    -> string defAttr "info" <> ctxLabel (ChannelFocus net chan)
+    FocusUsers net chan   -> string defAttr "names" <> ctxLabel (ChannelFocus net chan)
+    FocusMentions         -> string defAttr "mentions"
+    FocusPalette          -> string defAttr "palette"
+    FocusDigraphs         -> string defAttr "digraphs"
+    FocusKeyMap           -> string defAttr "keymap"
+    FocusHelp mb          -> string defAttr "help" <> opt mb
+    FocusIgnoreList       -> string defAttr "ignores"
+    FocusRtsStats         -> string defAttr "rtsstats"
+    FocusCert{}           -> string defAttr "cert"
+    FocusChanList net _ _ -> string defAttr "channels" <> ctxLabel (NetworkFocus net)
+    FocusWho net          -> string defAttr "who" <> whoTarget net
+    FocusMasks net chan m -> string defAttr "masks" <> maskLabel m <> ctxLabel (ChannelFocus net chan)
   where
+    !pal = clientPalette st
+    ctxLabel focus' = char defAttr ' ' <> focusLabel False st focus'
+    maskLabel m = char defAttr ':' <> char (view palLabel pal) m
     opt = foldMap (\cmd -> char defAttr ':' <>
                            text' (view palLabel pal) cmd)
+    windowName
+      | showFull = case preview (clientWindows . ix focus . winName . _Just) st of
+          Just n -> char (view palWindowName pal) n <> ":"
+          _      -> mempty
+      | otherwise = mempty
+    whoTarget net = case preview (clientConnection net . csWhoReply . whoQuery) st of
+      Just (query, _) | Text.null query -> ctxLabel (NetworkFocus net)
+      Just (query, _) -> ctxLabel (ChannelFocus net $ mkId query)
+      _ -> mempty
 
 windowFilterName :: WindowsFilter -> Maybe Text
 windowFilterName x =

--- a/src/Client/Image/Textbox.hs
+++ b/src/Client/Image/Textbox.hs
@@ -21,6 +21,7 @@ import Client.Commands.Arguments.Renderer (render)
 import Client.Commands.Arguments.Parser (parse)
 import Client.Commands.Interpolation (Macro(macroSpec), MacroSpec(..))
 import Client.Commands.Recognizer
+import Client.Commands.Types (makeArgsContext)
 import Client.Image.LineWrap (fullLineWrap, terminate)
 import Client.Image.Message (cleanChar, parseIrcTextWithNicks, Highlight)
 import Client.Image.MircFormatting (parseIrcText', plainText)
@@ -197,7 +198,7 @@ renderLine st pal hilites macros focused input =
                    <> string attr cleanCmd <> continue rest
       where
         specAttr spec =
-          case parse st spec rest of
+          case parse (makeArgsContext st) spec rest of
             Nothing -> view palCommand      pal
             Just{}  -> view palCommandReady pal
 
@@ -209,7 +210,7 @@ renderLine st pal hilites macros focused input =
           = case recognize (Text.toLower (Text.pack cmd)) allCommands of
               Exact (Right Command{cmdArgumentSpec = spec}) ->
                 ( specAttr spec
-                , render pal st focused spec
+                , render pal (makeArgsContext st) focused spec
                 )
               Exact (Left (MacroSpec spec)) ->
                 ( specAttr spec

--- a/src/Client/State/Url.hs
+++ b/src/Client/State/Url.hs
@@ -16,7 +16,7 @@ module Client.State.Url
 
 import           Client.Message (summaryActor)
 import           Client.State
-import           Client.State.Focus (Subfocus(..), focusNetwork, Focus)
+import           Client.State.Focus (Subfocus(..), focusNetwork, Focus, actualFocus)
 import           Client.State.Network
 import           Client.State.Window
 import           Client.WhoReply
@@ -70,15 +70,15 @@ urlList st = urlDedup $ urlListForFocus focus subfocus st
 
 urlListForFocus :: Focus -> Subfocus -> ClientState -> [UrlPair]
 urlListForFocus focus subfocus st = case (netM, subfocus) of
-  (Just cs, FocusChanList min' max') ->
+  (Just cs, FocusChanList _ min' max') ->
     matchesTopic st min' max' cs
-  (Just cs, FocusWho) ->
+  (Just cs, FocusWho _) ->
     matchesWhoReply st cs
   (_, _) ->
     toListOf (clientWindows . ix focus . winMessages . each . folding (matchesMsg st)) st
   where
     netM = do
-      net <- focusNetwork focus
+      net <- focusNetwork $ actualFocus subfocus focus
       view (clientConnections . at net) st
 
 matchesMsg :: ClientState -> WindowLine -> [UrlPair]

--- a/src/Client/View/ChannelList.hs
+++ b/src/Client/View/ChannelList.hs
@@ -57,8 +57,8 @@ channelListLines' cs width st (min', max')
                  string defAttr (show (length entries))
 
     queryPart = mconcat $
-      [text' (view palLabel pal) " More-than: " <> string defAttr (show lo) | FocusChanList (Just lo) _ <- [st^.clientSubfocus]] ++
-      [text' (view palLabel pal) " Less-than: " <> string defAttr (show hi) | FocusChanList _ (Just hi) <- [st^.clientSubfocus]] ++
+      [text' (view palLabel pal) " More-than: " <> string defAttr (show lo) | FocusChanList _ (Just lo) _ <- [st^.clientSubfocus]] ++
+      [text' (view palLabel pal) " Less-than: " <> string defAttr (show hi) | FocusChanList _ _ (Just hi) <- [st^.clientSubfocus]] ++
       [text' (view palLabel pal) " Elist: " <> text' defAttr txt | Just txt <- [els], not (Text.null txt)]
 
     entries = chanList^.clsItems


### PR DESCRIPTION
`/in` allows running focus-sensitive commands in a different focus than the current one.
Also lays some of the groundwork for potential future meta-commands
and adjusts how subfocuses are indicated in the status line and window title.

Caveats:
- `/masks` still doesn't work on channels that haven't been loaded yet.
This will require a minor change to how channel state is handled, namely creating ChannelState for channels one isn't in but marking those states as "stale".
- There's no tab completion for the command given to `/in`.
Tab completion needs big changes for this to work (maybe making it the responsibility of the argument spec rather than the command itself?).