### PR TITLE
Rewrite cleanText to strip zero width spaces characters

### DIFF
--- a/src/Client/Image/Message.hs
+++ b/src/Client/Image/Message.hs
@@ -112,7 +112,9 @@ cleanChar x
   | otherwise   = x
 
 cleanText :: Text -> Text
-cleanText = Text.map cleanChar
+cleanText = Text.concatMap f where
+  f c | c == '\8203' = Text.empty -- remove the zero width space the haskell bridge uses
+  f c = Text.singleton (cleanChar c)
 
 ctxt :: Text -> Image'
 ctxt = text' defAttr . cleanText


### PR DESCRIPTION
This is a fairly hack fix for the issue that I appear to be the only one suffering from.  Certain non-ascii characters cause text to get corrupted in my terminal when using glirc - when connected 

> (macOS ->) (Alacritty|Terminal.app) -> Mosh -> tmux -> glirc.

All have been configured to understand and use utf-8 characters, but the zero width spaces that get included in the nicks from haskellbridge cause things get garbled. See screen shot and particularly note that the text immediately after nicks:

<img width="755" alt="Screenshot 2024-05-01 at 20 58 42" src="https://github.com/glguy/irc-core/assets/39567/c07d0237-fb46-49e5-a019-31ee332f4c95">

This problem is so bad that it affects other tmux windows when I switch between them. While other unicode characters like emojis cause problems, the prevalence of the zero width space (see https://www.unicode.org/charts/PDF/U2000.pdf - code 0x200B) is used in the haskellbridge matrix bot on Libera.chat, which causes glirc to be nearly unreadable for me when many matrix users are speaking.

I'm sure this isn't the best implementation of the fix, but I couldn't think of an appropriate character that '\8203' should be replaced with that wouldn't look strange. More than happy to implement alternatives, this is more for discussion that necessarily the final fix.